### PR TITLE
Android gradle-related files update (http->https)

### DIFF
--- a/dependencies/extension-api/build.gradle
+++ b/dependencies/extension-api/build.gradle
@@ -1,11 +1,7 @@
 buildscript {
 	repositories {
-		jcenter {
-			url "http://jcenter.bintray.com/"
-		}
-		maven {
-			url 'https://maven.google.com/'
-		}
+		jcenter()
+		google()
 	}
 	
 	dependencies {

--- a/templates/android/template/build.gradle
+++ b/templates/android/template/build.gradle
@@ -2,12 +2,8 @@
 
 buildscript {
 	repositories {
-		jcenter {
-			url "http://jcenter.bintray.com/"
-		}
-		maven {
-			url "https://maven.google.com/"
-		}
+		jcenter()
+		google()
 	}
 	dependencies {
 		classpath 'com.android.tools.build:gradle:::ANDROID_GRADLE_PLUGIN::'
@@ -19,12 +15,8 @@ buildscript {
 
 allprojects {
 	repositories {
-		jcenter {
-			url "http://jcenter.bintray.com/"
-		}
-		maven {
-			url "https://maven.google.com"
-		}
+		jcenter()
+		google()
 	}::if ANDROID_GRADLE_BUILD_DIRECTORY::
 	buildDir = "::ANDROID_GRADLE_BUILD_DIRECTORY::/::APP_FILE::/${project.name}"::end::
 }
@@ -40,9 +32,8 @@ wrapper {
 configure(subprojects.findAll {!it.file('build.gradle').exists() && it.file('build.xml').exists()}) {
 	buildscript {
 		repositories {
-			maven {
-				url "https://maven.google.com/"
-			}
+			jcenter()
+			google()
 		}
 		
 		dependencies {

--- a/templates/android/template/gradle/wrapper/gradle-wrapper.properties
+++ b/templates/android/template/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-::ANDROID_GRADLE_VERSION::-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-::ANDROID_GRADLE_VERSION::-bin.zip

--- a/templates/extension/dependencies/android/build.gradle
+++ b/templates/extension/dependencies/android/build.gradle
@@ -1,11 +1,7 @@
 buildscript {
 	repositories {
-		jcenter {
-			url "http://jcenter.bintray.com/"
-		}
-		maven {
-			url "https://maven.google.com/"
-		}
+		jcenter()
+		google()
 	}
 	
 	dependencies {


### PR DESCRIPTION
- Use [gradle's built-in repository notations](https://docs.gradle.org/current/userguide/declaring_repositories.html) for jcenter & google.

- Use https for `distributonUrl` in gradle-wrapper.properties as `services.gradle.org/distributions/` is only accessible over https.