### PR TITLE
Update default iphone simulator

### DIFF
--- a/src/lime/tools/XCodeHelper.hx
+++ b/src/lime/tools/XCodeHelper.hx
@@ -6,7 +6,7 @@ import lime.tools.HXProject;
 class XCodeHelper
 {
 	private static inline var DEFAULT_IPAD_SIMULATOR = "ipad-air";
-	private static inline var DEFAULT_IPHONE_SIMULATOR = "iphone-6";
+	private static inline var DEFAULT_IPHONE_SIMULATOR = "iphone-11";
 
 	private static function extractSimulatorFlagName(line:String):String
 	{


### PR DESCRIPTION
Iphone 6 silmulator is no longer supported, updated to iphone 11

Fixes https://github.com/haxelime/lime/issues/1355