### PR TITLE
Fix compilation error with js array buffers (haxe 4)

### DIFF
--- a/src/lime/utils/Float32Array.hx
+++ b/src/lime/utils/Float32Array.hx
@@ -10,8 +10,10 @@ import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
 @:arrayAccess
-abstract Float32Array(JSFloat32Array) from JSFloat32Array to JSFloat32Array to ArrayBufferView
+abstract Float32Array(JSFloat32Array) from JSFloat32Array to JSFloat32Array
 {
+	@:to function toArrayBufferView ():ArrayBufferView return this;
+
 	public inline static var BYTES_PER_ELEMENT:Int = 4;
 
 	@:generic

--- a/src/lime/utils/Float64Array.hx
+++ b/src/lime/utils/Float64Array.hx
@@ -9,8 +9,10 @@ import js.html.Float64Array as JSFloat64Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract Float64Array(JSFloat64Array) from JSFloat64Array to JSFloat64Array to ArrayBufferView
+abstract Float64Array(JSFloat64Array) from JSFloat64Array to JSFloat64Array
 {
+	@:to inline function toArrayBufferView ():ArrayBufferView return this;
+	
 	public inline static var BYTES_PER_ELEMENT:Int = 8;
 
 	@:generic

--- a/src/lime/utils/Int16Array.hx
+++ b/src/lime/utils/Int16Array.hx
@@ -9,8 +9,10 @@ import js.html.Int16Array as JSInt16Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract Int16Array(JSInt16Array) from JSInt16Array to JSInt16Array to ArrayBufferView
+abstract Int16Array(JSInt16Array) from JSInt16Array to JSInt16Array
 {
+	@:to inline function toArrayBufferView ():ArrayBufferView return this;
+
 	public inline static var BYTES_PER_ELEMENT:Int = 2;
 
 	@:generic

--- a/src/lime/utils/Int32Array.hx
+++ b/src/lime/utils/Int32Array.hx
@@ -9,8 +9,10 @@ import js.html.Int32Array as JSInt32Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract Int32Array(JSInt32Array) from JSInt32Array to JSInt32Array to ArrayBufferView
+abstract Int32Array(JSInt32Array) from JSInt32Array to JSInt32Array
 {
+	@:to inline function toArrayBufferView ():ArrayBufferView return this;
+
 	public inline static var BYTES_PER_ELEMENT:Int = 4;
 
 	@:generic

--- a/src/lime/utils/Int8Array.hx
+++ b/src/lime/utils/Int8Array.hx
@@ -9,8 +9,10 @@ import js.html.Int8Array as JSInt8Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract Int8Array(JSInt8Array) from JSInt8Array to JSInt8Array to ArrayBufferView
+abstract Int8Array(JSInt8Array) from JSInt8Array to JSInt8Array
 {
+	@:to inline function toArrayBufferView ():ArrayBufferView return this;
+	
 	public inline static var BYTES_PER_ELEMENT:Int = 1;
 
 	@:generic

--- a/src/lime/utils/UInt16Array.hx
+++ b/src/lime/utils/UInt16Array.hx
@@ -9,8 +9,10 @@ import js.html.Uint8Array as JSUInt8Array;
 import js.html.Uint16Array as JSUInt16Array;
 #end
 @:forward
-abstract UInt16Array(JSUInt16Array) from JSUInt16Array to JSUInt16Array to ArrayBufferView
+abstract UInt16Array(JSUInt16Array) from JSUInt16Array to JSUInt16Array
 {
+	@:to inline function toArrayBufferView ():ArrayBufferView return this;
+	
 	public inline static var BYTES_PER_ELEMENT:Int = 2;
 
 	@:generic

--- a/src/lime/utils/UInt32Array.hx
+++ b/src/lime/utils/UInt32Array.hx
@@ -9,8 +9,10 @@ import js.html.Uint8Array as JSUInt8Array;
 import js.html.Uint32Array as JSUInt32Array;
 #end
 @:forward
-abstract UInt32Array(JSUInt32Array) from JSUInt32Array to JSUInt32Array to ArrayBufferView
+abstract UInt32Array(JSUInt32Array) from JSUInt32Array to JSUInt32Array
 {
+	@:to inline function toArrayBufferView ():ArrayBufferView return this;
+	
 	public inline static var BYTES_PER_ELEMENT:Int = 4;
 
 	@:generic

--- a/src/lime/utils/UInt8Array.hx
+++ b/src/lime/utils/UInt8Array.hx
@@ -7,8 +7,10 @@ import js.lib.Uint8Array as JSUInt8Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
-abstract UInt8Array(JSUInt8Array) from JSUInt8Array to JSUInt8Array to ArrayBufferView
+abstract UInt8Array(JSUInt8Array) from JSUInt8Array to JSUInt8Array
 {
+	@:to inline function toArrayBufferView ():ArrayBufferView return this;
+	
 	public inline static var BYTES_PER_ELEMENT:Int = 1;
 
 	@:generic

--- a/src/lime/utils/UInt8ClampedArray.hx
+++ b/src/lime/utils/UInt8ClampedArray.hx
@@ -9,8 +9,10 @@ import js.html.Uint8Array as JSUInt8Array;
 import js.html.Uint8ClampedArray as JSUInt8ClampedArray;
 #end
 @:forward
-abstract UInt8ClampedArray(JSUInt8ClampedArray) from JSUInt8ClampedArray to JSUInt8ClampedArray to ArrayBufferView
+abstract UInt8ClampedArray(JSUInt8ClampedArray) from JSUInt8ClampedArray to JSUInt8ClampedArray
 {
+	@:to inline function toArrayBufferView ():ArrayBufferView return this;
+	
 	public inline static var BYTES_PER_ELEMENT:Int = 1;
 
 	@:generic


### PR DESCRIPTION
This fixes a few compilation errors with some from/to casts with Haxe 4. I was getting the following error when building html5:

`You can only declare from/to with compatible types`

For some reason, using `@:to` instead of `abstract T (_) to` do the trick :)