### PR TITLE
Support for scoped lime projects

### DIFF
--- a/docs/build.hx
+++ b/docs/build.hx
@@ -56,10 +56,10 @@ class Build extends Script
 		html5.define("html5");
 		html5.build();
 
-		System.runCommand("", "haxelib", [
+		System.runCommand("", "haxelib " + [
 			"run", "dox", "-i", "xml", "-in", "lime", "--title", "Lime API Reference", "-D", "source-path",
 			"https://github.com/openfl/lime/tree/develop/src/", "-D", "website", "http://lime.software", "-D", "logo", "/images/logo.png", "-D", "textColor",
 			"0x777777", "-theme", "../assets/docs-theme", "--toplevel-package", "lime"
-		]);
+		].join(" "));
 	}
 }

--- a/src/lime/system/CFFI.hx
+++ b/src/lime/system/CFFI.hx
@@ -204,7 +204,7 @@ class CFFI
 		#if (sys && !macro && !html5)
 		try
 		{
-			var proc = new Process("haxelib", ["path", library]);
+			var proc = new Process("haxelib path "+ library);
 
 			if (proc != null)
 			{

--- a/src/lime/tools/AssetHelper.hx
+++ b/src/lime/tools/AssetHelper.hx
@@ -467,7 +467,7 @@ class AssetHelper
 			for (handler in handlers)
 			{
 				var outputFile = System.getTemporaryFile();
-				var args = ["run", handler, "process", temporaryFile, outputFile];
+				var args = ["run", '"$handler"', "process", '"$temporaryFile"', '"$outputFile"'];
 
 				if (Log.verbose)
 				{
@@ -476,12 +476,12 @@ class AssetHelper
 
 				if (targetDirectory != null)
 				{
-					args.push("--targetDirectory=" + Path.tryFullPath(targetDirectory));
+					args.push("--targetDirectory=\"" + Path.tryFullPath(targetDirectory) + '"');
 				}
 
 				try
 				{
-					Haxelib.runCommand("", args, false);
+					Haxelib.runCommand("", args, false, false, false, true);
 				}
 				catch (e:Dynamic)
 				{

--- a/src/lime/tools/AssetHelper.hx
+++ b/src/lime/tools/AssetHelper.hx
@@ -481,7 +481,7 @@ class AssetHelper
 
 				try
 				{
-					Haxelib.runCommand("", args, false, false, false, true);
+					Haxelib.runCommand("", args, false);
 				}
 				catch (e:Dynamic)
 				{

--- a/src/lime/tools/CPPHelper.hx
+++ b/src/lime/tools/CPPHelper.hx
@@ -116,7 +116,7 @@ class CPPHelper
 
 			Sys.putEnv("HXCPP_EXIT_ON_ERROR", "");
 
-			var code = Haxelib.runCommand(path, args);
+			var code = Haxelib.runCommand(path, args, false, false, false, true);
 
 			if (code != 0)
 			{
@@ -275,6 +275,6 @@ class CPPHelper
 
 		Sys.putEnv("HXCPP_EXIT_ON_ERROR", "");
 
-		Haxelib.runCommand(path, args);
+		Haxelib.runCommand(path, args, false, false, false, true);
 	}
 }

--- a/src/lime/tools/CPPHelper.hx
+++ b/src/lime/tools/CPPHelper.hx
@@ -116,7 +116,7 @@ class CPPHelper
 
 			Sys.putEnv("HXCPP_EXIT_ON_ERROR", "");
 
-			var code = Haxelib.runCommand(path, args, false, false, false, true);
+			var code = Haxelib.runCommand(path, args, false);
 
 			if (code != 0)
 			{
@@ -286,7 +286,7 @@ class CPPHelper
 
 		Sys.putEnv("HXCPP_EXIT_ON_ERROR", "");
 
-		Haxelib.runCommand(path, args, false, false, false, true);
+		Haxelib.runCommand(path, args, false);
 
 		if (scoped)
 		{

--- a/src/lime/tools/CPPHelper.hx
+++ b/src/lime/tools/CPPHelper.hx
@@ -273,8 +273,24 @@ class CPPHelper
 			Sys.putEnv("HXCPP_COMPILE_THREADS", Std.string(threads));
 		}
 
+		var scoped = FileSystem.exists(".lime") && FileSystem.isDirectory(".lime");
+
+		if (scoped)
+		{
+			var localPath = ".lime/temp";
+
+			System.recursiveCopy(path, ".lime/temp");
+
+			path = ".lime/temp";
+		}
+
 		Sys.putEnv("HXCPP_EXIT_ON_ERROR", "");
 
 		Haxelib.runCommand(path, args, false, false, false, true);
+
+		if (scoped)
+		{
+			System.removeDirectory(path);
+		}
 	}
 }

--- a/src/lime/tools/CSHelper.hx
+++ b/src/lime/tools/CSHelper.hx
@@ -224,7 +224,7 @@ class CSHelper
 			"run", project.config.getString("cs.buildLibrary", "hxcs"), buildFile, "--arch", arch, "--platform", platform, "--out", outPath, "--unsafe"
 		];
 		if (noCompile) args.push("--no-compile");
-		var code = Haxelib.runCommand(path, args);
+		var code = Haxelib.runCommand(path, args, false, false, false, true);
 
 		if (code != 0)
 		{

--- a/src/lime/tools/CSHelper.hx
+++ b/src/lime/tools/CSHelper.hx
@@ -224,7 +224,7 @@ class CSHelper
 			"run", project.config.getString("cs.buildLibrary", "hxcs"), buildFile, "--arch", arch, "--platform", platform, "--out", outPath, "--unsafe"
 		];
 		if (noCompile) args.push("--no-compile");
-		var code = Haxelib.runCommand(path, args, false, false, false, true);
+		var code = Haxelib.runCommand(path, args, false);
 
 		if (code != 0)
 		{

--- a/src/lime/tools/FlashHelper.hx
+++ b/src/lime/tools/FlashHelper.hx
@@ -743,13 +743,13 @@ class FlashHelper
 			// Have to daisy-chain it to fix Haxe compiler issue
 
 			args.push ("-swf-lib");
-			args.push (destination + "/.assets.swf");
+			args.push ("\"" + destination + "/.assets.swf\"");
 			args.push ("-D");
 			args.push ("flash-use-stage");
 
 		}
 
-		System.runCommand ("", "haxe", args);
+		System.runCommand ("", "haxe " + args.join(" "), null);
 
 		if (FileSystem.exists (destination + "/.assets.swf")) {
 

--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -1258,7 +1258,7 @@ class HXProject extends Script
 
 				try
 				{
-					output = Haxelib.runProcess("", ["path", name], true, true, true, false, false, true);
+					output = Haxelib.runProcess("", ["path", name], true, true, true);
 				}
 				catch (e:Dynamic) {}
 

--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -532,12 +532,13 @@ class HXProject extends Script
 		var tempDirectory = System.getTemporaryDirectory();
 		var classFile = Path.combine(tempDirectory, name + ".hx");
 		var nekoOutput = Path.combine(tempDirectory, name + ".n");
+		var hxpSourcesPath = Path.combine(Haxelib.getPath(new Haxelib("hxp")), "src");
 
 		System.copyFile(path, classFile);
 
 		#if lime
 		var args = [
-			name, "-main", "lime.tools.HXProject", "-cp", tempDirectory, "-neko", nekoOutput, "-cp", Path.combine(Haxelib.getPath(new Haxelib("hxp")), "src"),
+			name, "-main", "lime.tools.HXProject", "-cp", '"$tempDirectory"', "-neko", '"$nekoOutput"', "-cp", '"$hxpSourcesPath"',
 			"-lib", "lime", "-lib", "hxp"
 		];
 		#else
@@ -547,9 +548,9 @@ class HXProject extends Script
 			"-main",
 			"lime.tools.HXProject",
 			"-cp",
-			tempDirectory,
+			'"$tempDirectory"',
 			"-cp",
-			Path.combine(Haxelib.getPath(new Haxelib("hxp")), "src")
+			'"$hxpSourcesPath"'
 		];
 		#end
 		var input = File.read(classFile, false);
@@ -575,7 +576,7 @@ class HXProject extends Script
 		System.dryRun = false;
 
 		#if lime
-		System.runCommand("", "haxe", args);
+		System.runCommand("", "haxe " + args.join(" "), null);
 		#end
 
 		var inputFile = Path.combine(tempDirectory, "input.dat");
@@ -602,9 +603,9 @@ class HXProject extends Script
 		try
 		{
 			#if lime
-			System.runCommand("", "neko", [FileSystem.fullPath(nekoOutput), inputFile, outputFile]);
+			System.runCommand("", 'neko "${FileSystem.fullPath(nekoOutput)}" "$inputFile" "$outputFile"', null);
 			#else
-			System.runCommand("", "haxe", args.concat(["--", inputFile, outputFile]));
+			System.runCommand("", "haxe " + args.concat(["--", '"$inputFile"', '"$outputFile"']).join(" "), null);
 			#end
 		}
 		catch (e:Dynamic)
@@ -1257,7 +1258,7 @@ class HXProject extends Script
 
 				try
 				{
-					output = Haxelib.runProcess("", ["path", name], true, true, true);
+					output = Haxelib.runProcess("", ["path", name], true, true, true, false, false, true);
 				}
 				catch (e:Dynamic) {}
 

--- a/src/lime/tools/ImageHelper.hx
+++ b/src/lime/tools/ImageHelper.hx
@@ -25,14 +25,14 @@ class ImageHelper
 
 		try
 		{
-			System.runCommand("", "neko", [
+			System.runCommand("", "neko " + [
 				Path.combine(Haxelib.getPath(new Haxelib(#if lime "lime" #else "hxp" #end)), "svg.n"),
 				"process",
-				path,
+				'"$path"',
 				Std.string(width),
 				Std.string(height),
-				temp
-			], true, true);
+				'"$temp"'
+			].join(" "), null, true, true);
 
 			if (FileSystem.exists(temp))
 			{

--- a/src/lime/tools/ModuleHelper.hx
+++ b/src/lime/tools/ModuleHelper.hx
@@ -119,7 +119,7 @@ class ModuleHelper
 				File.saveContent(importPath, moduleImport);
 				File.saveContent(hxmlPath, hxml);
 
-				System.runCommand("", "haxe", [hxmlPath]);
+				System.runCommand("", 'haxe "$hxmlPath"', null);
 
 				patchFile(outputPath);
 

--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -303,7 +303,7 @@ class CommandLineTools
 							var cacheValue = Sys.getEnv("HAXELIB_PATH");
 							Sys.putEnv("HAXELIB_PATH", Haxelib.getRepositoryPath());
 
-							System.runCommand(Path.directory(hxmlPath), "haxe", [Path.withoutDirectory(hxmlPath)]);
+							HXML.buildFile(hxmlPath, Sys.getCwd());
 
 							if (cacheValue != null)
 							{
@@ -437,7 +437,11 @@ class CommandLineTools
 
 		var path = "";
 
-		if (FileSystem.exists("tools.n"))
+		if (Path.normalize(Sys.getCwd()).substr(-6, 6) == "/.lime")
+		{
+			path = Path.combine(Sys.getCwd(), "/ndll/");
+		}
+		else if (FileSystem.exists("tools.n"))
 		{
 			path = Path.combine(Sys.getCwd(), "../ndll/");
 		}
@@ -448,7 +452,7 @@ class CommandLineTools
 
 		if (path == "")
 		{
-			var process = new Process("haxelib", ["path", "lime"]);
+			var process = new Process("haxelib path lime");
 
 			try
 			{
@@ -548,7 +552,7 @@ class CommandLineTools
 			var exePath = Path.join([targetDir, "run.exe"]);
 			var exeExists = FileSystem.exists(exePath);
 
-			var args = [command, temporaryFile];
+			var args = [command, '"$temporaryFile"'];
 
 			if (Log.verbose) args.push("-verbose");
 			if (!Log.enableColor) args.push("-nocolor");
@@ -566,7 +570,7 @@ class CommandLineTools
 			}
 			else
 			{
-				Haxelib.runCommand("", ["run", handler].concat(args));
+				Haxelib.runCommand("", ["run", handler].concat(args), false, false, false, true);
 			}
 
 			try
@@ -1216,14 +1220,14 @@ class CommandLineTools
 			var sourcePath = words[0];
 			var glyphs = "32-255";
 
-			System.runCommand(Path.directory(sourcePath), "neko", [
-				Haxelib.getPath(new Haxelib("lime")) + "/templates/bin/hxswfml.n",
+			System.runCommand(Path.directory(sourcePath), "neko " + [
+				'"${Haxelib.getPath(new Haxelib("lime")) + "/templates/bin/hxswfml.n"}"',
 				"ttf2hash2",
-				Path.withoutDirectory(sourcePath),
-				Path.withoutDirectory(sourcePath) + ".hash",
+				'"${Path.withoutDirectory(sourcePath)}"',
+				'"${Path.withoutDirectory(sourcePath) + ".hash"}"',
 				"-glyphs",
 				glyphs
-			]);
+			].join(" "), null);
 		}
 		else if (targetFlags.exists("font-details"))
 		{
@@ -1643,7 +1647,7 @@ class CommandLineTools
 
 		try
 		{
-			var process = new Process("haxe", ["-version"]);
+			var process = new Process("haxe -version");
 			var haxeVersion = StringTools.trim(process.stderr.readAll().toString());
 
 			if (haxeVersion == "")
@@ -2324,7 +2328,7 @@ class CommandLineTools
 			case "remove":
 				if (path != null && path != "")
 				{
-					Haxelib.runCommand("", ["remove", name]);
+					Haxelib.runCommand("", ["remove", name], false, false, false, true);
 				}
 
 			case "upgrade":

--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -570,7 +570,7 @@ class CommandLineTools
 			}
 			else
 			{
-				Haxelib.runCommand("", ["run", handler].concat(args), false, false, false, true);
+				Haxelib.runCommand("", ["run", handler].concat(args), false);
 			}
 
 			try
@@ -2328,7 +2328,7 @@ class CommandLineTools
 			case "remove":
 				if (path != null && path != "")
 				{
-					Haxelib.runCommand("", ["remove", name], false, false, false, true);
+					Haxelib.runCommand("", ["remove", name], false);
 				}
 
 			case "upgrade":

--- a/tools/SVGExport.hx
+++ b/tools/SVGExport.hx
@@ -29,7 +29,7 @@ class SVGExport
 
 		if (path == "")
 		{
-			var process = new Process("haxelib", ["path", "lime"]);
+			var process = new Process("haxelib path lime");
 
 			try
 			{

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -71,7 +71,7 @@ class AndroidPlatform extends PlatformTarget
 
 		for (architecture in architectures)
 		{
-			var haxeParams = [hxml, "-D", "android", "-D", "PLATFORM=android-16"];
+			var haxeParams = ['"$hxml"', "-D", "android", "-D", "PLATFORM=android-16"];
 			var cppParams = ["-Dandroid", "-DPLATFORM=android-16"];
 			var path = sourceSet + "/jniLibs/armeabi";
 			var suffix = ".so";
@@ -86,7 +86,7 @@ class AndroidPlatform extends PlatformTarget
 			}
 			else if (architecture == Architecture.ARM64)
 			{
-				haxeParams = [hxml, "-D", "android", "-D", "PLATFORM=android-21"];
+				haxeParams = ['"$hxml"', "-D", "android", "-D", "PLATFORM=android-21"];
 				cppParams = ["-Dandroid", "-DPLATFORM=android-21"];
 
 				haxeParams.push("-D");
@@ -105,7 +105,7 @@ class AndroidPlatform extends PlatformTarget
 			}
 			else if (architecture == Architecture.X64)
 			{
-				haxeParams = [hxml, "-D", "android", "-D", "PLATFORM=android-21"];
+				haxeParams = ['"$hxml"', "-D", "android", "-D", "PLATFORM=android-21"];
 				cppParams = ["-Dandroid", "-DPLATFORM=android-21"];
 
 				haxeParams.push("-D");
@@ -120,7 +120,7 @@ class AndroidPlatform extends PlatformTarget
 				ProjectHelper.copyLibrary(project, ndll, "Android", "lib", suffix, path, project.debug, ".so");
 			}
 
-			System.runCommand("", "haxe", haxeParams);
+			System.runCommand("", "haxe " + haxeParams.join(" "), null);
 
 			if (noOutput) return;
 

--- a/tools/platforms/EmscriptenPlatform.hx
+++ b/tools/platforms/EmscriptenPlatform.hx
@@ -49,7 +49,7 @@ class EmscriptenPlatform extends PlatformTarget
 		}
 
 		var hxml = targetDirectory + "/haxe/" + buildType + ".hxml";
-		var args = [hxml, "-D", "emscripten", "-D", "webgl", "-D", "static_link"];
+		var args = ['"$hxml"', "-D", "emscripten", "-D", "webgl", "-D", "static_link"];
 
 		if (Log.verbose)
 		{
@@ -57,7 +57,7 @@ class EmscriptenPlatform extends PlatformTarget
 			args.push("verbose");
 		}
 
-		System.runCommand("", "haxe", args);
+		System.runCommand("", "haxe " + args.join(" "), null);
 
 		if (noOutput) return;
 

--- a/tools/platforms/FlashPlatform.hx
+++ b/tools/platforms/FlashPlatform.hx
@@ -38,7 +38,8 @@ class FlashPlatform extends PlatformTarget
 
 	public override function build():Void
 	{
-		System.runCommand("", "haxe", [targetDirectory + "/haxe/" + buildType + ".hxml"]);
+		var hxml = targetDirectory + "/haxe/" + buildType + ".hxml";
+		System.runCommand("", 'haxe "$hxml"', null);
 	}
 
 	public override function clean():Void

--- a/tools/platforms/HTML5Platform.hx
+++ b/tools/platforms/HTML5Platform.hx
@@ -66,7 +66,7 @@ class HTML5Platform extends PlatformTarget
 			}
 
 			var hxml = targetDirectory + "/haxe/" + type + ".hxml";
-			System.runCommand("", "haxe", [hxml]);
+			System.runCommand("", 'haxe "$hxml"', null);
 
 			if (noOutput) return;
 

--- a/tools/platforms/LinuxPlatform.hx
+++ b/tools/platforms/LinuxPlatform.hx
@@ -116,7 +116,7 @@ class LinuxPlatform extends PlatformTarget
 
 		if (targetType == "neko")
 		{
-			System.runCommand("", "haxe", [hxml]);
+			System.runCommand("", 'haxe "$hxml"', null);
 
 			if (noOutput) return;
 
@@ -133,7 +133,7 @@ class LinuxPlatform extends PlatformTarget
 		}
 		else if (targetType == "hl")
 		{
-			System.runCommand("", "haxe", [hxml]);
+			System.runCommand("", 'haxe "$hxml"', null);
 
 			if (noOutput) return;
 
@@ -145,7 +145,7 @@ class LinuxPlatform extends PlatformTarget
 		}
 		else if (targetType == "nodejs")
 		{
-			System.runCommand("", "haxe", [hxml]);
+			System.runCommand("", 'haxe "$hxml"', null);
 			// NekoHelper.createExecutable (project.templatePaths, "linux" + (is64 ? "64" : ""), targetDirectory + "/obj/ApplicationMain.n", executablePath);
 			// NekoHelper.copyLibraries (project.templatePaths, "linux" + (is64 ? "64" : ""), applicationDirectory);
 		}
@@ -153,7 +153,7 @@ class LinuxPlatform extends PlatformTarget
 		{
 			var libPath = Path.combine(Haxelib.getPath(new Haxelib("lime")), "templates/java/lib/");
 
-			System.runCommand("", "haxe", [hxml, "-java-lib", libPath + "disruptor.jar", "-java-lib", libPath + "lwjgl.jar"]);
+			System.runCommand("", "haxe " + ['"$hxml"', "-java-lib", '"$libPath"' + "disruptor.jar", "-java-lib", '"$libPath"' + "lwjgl.jar"].join(" "), null);
 			// System.runCommand ("", "haxe", [ hxml ]);
 
 			if (noOutput) return;
@@ -168,7 +168,7 @@ class LinuxPlatform extends PlatformTarget
 					+ (haxeVersion.length == 5 ? "0" + haxeVersion.charAt(4) : haxeVersion.charAt(4) + haxeVersion.charAt(5));
 			}
 
-			System.runCommand(targetDirectory + "/obj", "haxelib", ["run", "hxjava", "hxjava_build.txt", "--haxe-version", haxeVersionString]);
+			System.runCommand(targetDirectory + "/obj", "haxelib run hxjava hxjava_build.txt --haxe-version " + haxeVersionString, null);
 			System.recursiveCopy(targetDirectory + "/obj/lib", Path.combine(applicationDirectory, "lib"));
 			System.copyFile(targetDirectory + "/obj/ApplicationMain" + (project.debug ? "-Debug" : "") + ".jar",
 				Path.combine(applicationDirectory, project.app.file + ".jar"));
@@ -176,7 +176,7 @@ class LinuxPlatform extends PlatformTarget
 		}
 		else
 		{
-			var haxeArgs = [hxml];
+			var haxeArgs = ['"$hxml"'];
 			var flags = [];
 
 			if (is64)
@@ -194,7 +194,7 @@ class LinuxPlatform extends PlatformTarget
 
 			if (!project.targetFlags.exists("static"))
 			{
-				System.runCommand("", "haxe", haxeArgs);
+				System.runCommand("", "haxe " + haxeArgs.join(" "), null);
 
 				if (noOutput) return;
 
@@ -204,7 +204,7 @@ class LinuxPlatform extends PlatformTarget
 			}
 			else
 			{
-				System.runCommand("", "haxe", haxeArgs.concat(["-D", "static_link"]));
+				System.runCommand("", "haxe " + haxeArgs.concat(["-D", "static_link"]).join(" "), null);
 
 				if (noOutput) return;
 

--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -109,7 +109,7 @@ class MacPlatform extends PlatformTarget
 
 		if (targetType == "neko")
 		{
-			System.runCommand("", "haxe", [hxml]);
+			System.runCommand("", 'haxe "$hxml"', null);
 
 			if (noOutput) return;
 
@@ -118,7 +118,7 @@ class MacPlatform extends PlatformTarget
 		}
 		else if (targetType == "hl")
 		{
-			System.runCommand("", "haxe", [hxml]);
+			System.runCommand("", 'haxe "$hxml"', null);
 
 			if (noOutput) return;
 
@@ -132,11 +132,11 @@ class MacPlatform extends PlatformTarget
 		{
 			var libPath = Path.combine(Haxelib.getPath(new Haxelib("lime")), "templates/java/lib/");
 
-			System.runCommand("", "haxe", [hxml, "-java-lib", libPath + "disruptor.jar", "-java-lib", libPath + "lwjgl.jar"]);
+			System.runCommand("", "haxe " + ['"$hxml"', "-java-lib", '"$libPath"' + "disruptor.jar", "-java-lib", '"$libPath"' + "lwjgl.jar"].join(" "), null);
 
 			if (noOutput) return;
 
-			Haxelib.runCommand(targetDirectory + "/obj", ["run", "hxjava", "hxjava_build.txt", "--haxe-version", "3103"]);
+			Haxelib.runCommand(targetDirectory + "/obj", ["run", "hxjava", "hxjava_build.txt", "--haxe-version", "3103"], false, false, false, true);
 			System.recursiveCopy(targetDirectory + "/obj/lib", Path.combine(executableDirectory, "lib"));
 			System.copyFile(targetDirectory + "/obj/ApplicationMain" + (project.debug ? "-Debug" : "") + ".jar",
 				Path.combine(executableDirectory, project.app.file + ".jar"));
@@ -144,7 +144,7 @@ class MacPlatform extends PlatformTarget
 		}
 		else if (targetType == "nodejs")
 		{
-			System.runCommand("", "haxe", [hxml]);
+			System.runCommand("", 'haxe "$hxml"', null);
 
 			if (noOutput) return;
 
@@ -153,7 +153,7 @@ class MacPlatform extends PlatformTarget
 		}
 		else if (targetType == "cs")
 		{
-			System.runCommand("", "haxe", [hxml]);
+			System.runCommand("", 'haxe "$hxml"', null);
 
 			if (noOutput) return;
 
@@ -167,7 +167,7 @@ class MacPlatform extends PlatformTarget
 		}
 		else
 		{
-			var haxeArgs = [hxml, "-D", "HXCPP_CLANG"];
+			var haxeArgs = ['"$hxml"', "-D", "HXCPP_CLANG"];
 			var flags = ["-DHXCPP_CLANG"];
 
 			if (is64)
@@ -179,7 +179,7 @@ class MacPlatform extends PlatformTarget
 
 			if (!project.targetFlags.exists("static"))
 			{
-				System.runCommand("", "haxe", haxeArgs);
+				System.runCommand("", "haxe " + haxeArgs.join(" "), null);
 
 				if (noOutput) return;
 
@@ -189,7 +189,7 @@ class MacPlatform extends PlatformTarget
 			}
 			else
 			{
-				System.runCommand("", "haxe", haxeArgs.concat(["-D", "static_link"]));
+				System.runCommand("", "haxe " + haxeArgs.concat(["-D", "static_link"]).join(" "), null);
 
 				if (noOutput) return;
 

--- a/tools/platforms/MacPlatform.hx
+++ b/tools/platforms/MacPlatform.hx
@@ -136,7 +136,7 @@ class MacPlatform extends PlatformTarget
 
 			if (noOutput) return;
 
-			Haxelib.runCommand(targetDirectory + "/obj", ["run", "hxjava", "hxjava_build.txt", "--haxe-version", "3103"], false, false, false, true);
+			Haxelib.runCommand(targetDirectory + "/obj", ["run", "hxjava", "hxjava_build.txt", "--haxe-version", "3103"], false);
 			System.recursiveCopy(targetDirectory + "/obj/lib", Path.combine(executableDirectory, "lib"));
 			System.copyFile(targetDirectory + "/obj/ApplicationMain" + (project.debug ? "-Debug" : "") + ".jar",
 				Path.combine(executableDirectory, project.app.file + ".jar"));

--- a/tools/platforms/TizenPlatform.hx
+++ b/tools/platforms/TizenPlatform.hx
@@ -45,7 +45,7 @@ class TizenPlatform extends PlatformTarget
 
 		var hxml = targetDirectory + "/haxe/" + buildType + ".hxml";
 
-		System.runCommand("", "haxe", [hxml, "-D", "tizen"]);
+		System.runCommand("", 'haxe "$hxml" -D tizen', null);
 
 		if (noOutput) return;
 

--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -92,7 +92,7 @@ class WindowsPlatform extends PlatformTarget
 				{
 					try
 					{
-						var process = new Process("haxe", ["-version"]);
+						var process = new Process("haxe -version");
 						var haxeVersion = StringTools.trim(process.stderr.readAll().toString());
 						if (haxeVersion == "")
 						{
@@ -143,7 +143,7 @@ class WindowsPlatform extends PlatformTarget
 
 			if (project.app.main != null)
 			{
-				System.runCommand("", "haxe", [hxml]);
+				System.runCommand("", 'haxe "$hxml"', null);
 
 				var msBuildPath = "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community\\MSBuild\\15.0\\Bin\\MSBuild.exe";
 				var args = [
@@ -218,7 +218,7 @@ class WindowsPlatform extends PlatformTarget
 
 			if (targetType == "neko")
 			{
-				System.runCommand("", "haxe", [hxml]);
+				System.runCommand("", 'haxe "$hxml"', null);
 
 				if (noOutput) return;
 
@@ -234,7 +234,7 @@ class WindowsPlatform extends PlatformTarget
 			}
 			else if (targetType == "hl")
 			{
-				System.runCommand("", "haxe", [hxml]);
+				System.runCommand("", 'haxe "$hxml"', null);
 
 				if (noOutput) return;
 
@@ -253,7 +253,7 @@ class WindowsPlatform extends PlatformTarget
 			}
 			else if (targetType == "cppia")
 			{
-				System.runCommand("", "haxe", [hxml]);
+				System.runCommand("", 'haxe "$hxml"', null);
 
 				if (noOutput) return;
 
@@ -270,7 +270,7 @@ class WindowsPlatform extends PlatformTarget
 			}
 			else if (targetType == "nodejs")
 			{
-				System.runCommand("", "haxe", [hxml]);
+				System.runCommand("", 'haxe "$hxml"', null);
 
 				if (noOutput) return;
 
@@ -279,7 +279,7 @@ class WindowsPlatform extends PlatformTarget
 			}
 			else if (targetType == "cs")
 			{
-				System.runCommand("", "haxe", [hxml]);
+				System.runCommand("", 'haxe "$hxml"', null);
 
 				if (noOutput) return;
 
@@ -293,8 +293,8 @@ class WindowsPlatform extends PlatformTarget
 			{
 				var libPath = Path.combine(Haxelib.getPath(new Haxelib("lime")), "templates/java/lib/");
 
-				System.runCommand("", "haxe", [hxml, "-java-lib", libPath + "disruptor.jar", "-java-lib", libPath + "lwjgl.jar"]);
-				// System.runCommand ("", "haxe", [ hxml ]);
+				System.runCommand("", 'haxe "$hxml" -java-lib "${libPath + "disruptor.jar"}" -java-lib "${libPath + "lwjgl.jar"}"', null);
+				// System.runCommand ("", "haxe " + hxml, null);
 
 				if (noOutput) return;
 
@@ -308,7 +308,7 @@ class WindowsPlatform extends PlatformTarget
 						+ (haxeVersion.length == 5 ? "0" + haxeVersion.charAt(4) : haxeVersion.charAt(4) + haxeVersion.charAt(5));
 				}
 
-				System.runCommand(targetDirectory + "/obj", "haxelib", ["run", "hxjava", "hxjava_build.txt", "--haxe-version", haxeVersionString]);
+				System.runCommand(targetDirectory + "/obj", "haxelib run hxjava hxjava_build.txt --haxe-version " + haxeVersionString, null);
 				System.recursiveCopy(targetDirectory + "/obj/lib", Path.combine(applicationDirectory, "lib"));
 				System.copyFile(targetDirectory + "/obj/ApplicationMain" + (project.debug ? "-Debug" : "") + ".jar",
 					Path.combine(applicationDirectory, project.app.file + ".jar"));
@@ -316,7 +316,7 @@ class WindowsPlatform extends PlatformTarget
 			}
 			else if (targetType == "winrt")
 			{
-				var haxeArgs = [hxml];
+				var haxeArgs = ['"$hxml"'];
 				var flags = [];
 
 				haxeArgs.push("-D");
@@ -345,7 +345,7 @@ class WindowsPlatform extends PlatformTarget
 
 				if (!project.targetFlags.exists("static"))
 				{
-					System.runCommand("", "haxe", haxeArgs);
+					System.runCommand("", "haxe " + haxeArgs.join(" "), null);
 
 					if (noOutput) return;
 
@@ -355,7 +355,7 @@ class WindowsPlatform extends PlatformTarget
 				}
 				else
 				{
-					System.runCommand("", "haxe", haxeArgs.concat(["-D", "static_link"]));
+					System.runCommand("", "haxe " + haxeArgs.join(" ") + " -D static_link", null);
 
 					if (noOutput) return;
 
@@ -376,7 +376,7 @@ class WindowsPlatform extends PlatformTarget
 			}
 			else
 			{
-				var haxeArgs = [hxml];
+				var haxeArgs = ['"$hxml"'];
 				var flags = [];
 
 				if (is64)
@@ -399,7 +399,7 @@ class WindowsPlatform extends PlatformTarget
 
 				if (!project.targetFlags.exists("static"))
 				{
-					System.runCommand("", "haxe", haxeArgs);
+					System.runCommand("", "haxe " + haxeArgs.join(" "), null);
 
 					if (noOutput) return;
 
@@ -409,7 +409,7 @@ class WindowsPlatform extends PlatformTarget
 				}
 				else
 				{
-					System.runCommand("", "haxe", haxeArgs.concat(["-D", "static_link"]));
+					System.runCommand("", "haxe " + haxeArgs.join(" ") + " -D static_link", null);
 
 					if (noOutput) return;
 

--- a/tools/utils/JavaExternGenerator.hx
+++ b/tools/utils/JavaExternGenerator.hx
@@ -205,7 +205,7 @@ class JavaExternGenerator
 
 	public static function getHaxelib(library:String):String
 	{
-		var proc = new Process("haxelib", ["path", library]);
+		var proc = new Process("haxelib path " + library);
 		var result = "";
 
 		try

--- a/tools/utils/PlatformSetup.hx
+++ b/tools/utils/PlatformSetup.hx
@@ -272,7 +272,7 @@ class PlatformSetup
 		if (version != null && version.indexOf("*") > -1)
 		{
 			var regexp = new EReg("^.+[0-9]+-[0-9]+-[0-9]+ +[0-9]+:[0-9]+:[0-9]+ +([a-z0-9.-]+) +", "gi");
-			var output = Haxelib.runProcess("", ["info", haxelib.name], true, true, false, false, false, true);
+			var output = Haxelib.runProcess("", ["info", haxelib.name]);
 			var lines = output.split("\n");
 
 			var versions = new Array<Version>();
@@ -310,7 +310,7 @@ class PlatformSetup
 			args.push(version);
 		}
 
-		Haxelib.runCommand("", args, false, false, false, true);
+		Haxelib.runCommand("", args, false);
 	}
 
 	private static function link(dir:String, file:String, dest:String):Void
@@ -615,7 +615,7 @@ class PlatformSetup
 		getDefineValue("ELECTRON_PATH", "Path to Electron runtime");
 
 		Log.println("");
-		Haxelib.runCommand("", ["install", "electron"], true, true, false, true);
+		Haxelib.runCommand("", ["install", "electron"], true, true);
 
 		Log.println("");
 		Log.println("Setup complete.");
@@ -640,7 +640,7 @@ class PlatformSetup
 		var defines = new Map<String, Dynamic>();
 		defines.set("setup", 1);
 
-		var basePath = Haxelib.runProcess("", ["config"], true, true, false, false, false, true);
+		var basePath = Haxelib.runProcess("", ["config"], true, true);
 		if (basePath != null)
 		{
 			basePath = StringTools.trim(basePath.split("\n")[0]);
@@ -1176,7 +1176,7 @@ class PlatformSetup
 
 	public static function updateHaxelib(haxelib:Haxelib):Void
 	{
-		var basePath = Haxelib.runProcess("", ["config"], true, true, false, false, false, true);
+		var basePath = Haxelib.runProcess("", ["config"], true, true);
 
 		if (basePath != null)
 		{
@@ -1187,7 +1187,7 @@ class PlatformSetup
 
 		if (StringTools.startsWith(Path.standardize(lib), Path.standardize(basePath)))
 		{
-			Haxelib.runCommand("", ["update", haxelib.name], false, false, false, true);
+			Haxelib.runCommand("", ["update", haxelib.name], false);
 		}
 		else
 		{

--- a/tools/utils/PlatformSetup.hx
+++ b/tools/utils/PlatformSetup.hx
@@ -272,7 +272,7 @@ class PlatformSetup
 		if (version != null && version.indexOf("*") > -1)
 		{
 			var regexp = new EReg("^.+[0-9]+-[0-9]+-[0-9]+ +[0-9]+:[0-9]+:[0-9]+ +([a-z0-9.-]+) +", "gi");
-			var output = Haxelib.runProcess("", ["info", haxelib.name]);
+			var output = Haxelib.runProcess("", ["info", haxelib.name], true, true, false, false, false, true);
 			var lines = output.split("\n");
 
 			var versions = new Array<Version>();
@@ -310,7 +310,7 @@ class PlatformSetup
 			args.push(version);
 		}
 
-		Haxelib.runCommand("", args);
+		Haxelib.runCommand("", args, false, false, false, true);
 	}
 
 	private static function link(dir:String, file:String, dest:String):Void
@@ -615,7 +615,7 @@ class PlatformSetup
 		getDefineValue("ELECTRON_PATH", "Path to Electron runtime");
 
 		Log.println("");
-		Haxelib.runCommand("", ["install", "electron"], true, true);
+		Haxelib.runCommand("", ["install", "electron"], true, true, false, true);
 
 		Log.println("");
 		Log.println("Setup complete.");
@@ -640,7 +640,7 @@ class PlatformSetup
 		var defines = new Map<String, Dynamic>();
 		defines.set("setup", 1);
 
-		var basePath = Haxelib.runProcess("", ["config"]);
+		var basePath = Haxelib.runProcess("", ["config"], true, true, false, false, false, true);
 		if (basePath != null)
 		{
 			basePath = StringTools.trim(basePath.split("\n")[0]);
@@ -1176,7 +1176,7 @@ class PlatformSetup
 
 	public static function updateHaxelib(haxelib:Haxelib):Void
 	{
-		var basePath = Haxelib.runProcess("", ["config"]);
+		var basePath = Haxelib.runProcess("", ["config"], true, true, false, false, false, true);
 
 		if (basePath != null)
 		{
@@ -1187,7 +1187,7 @@ class PlatformSetup
 
 		if (StringTools.startsWith(Path.standardize(lib), Path.standardize(basePath)))
 		{
-			Haxelib.runCommand("", ["update", haxelib.name]);
+			Haxelib.runCommand("", ["update", haxelib.name], false, false, false, true);
 		}
 		else
 		{


### PR DESCRIPTION
This put the foundation to set up lime projects within scopes. Meaning full support for lix, and more generally easier project switching. This PR requires openfl/hxp#18 to be merged.

### Changes:
- new command `lime scope create`: create a directory `.lime` in the specified working directory.
- if existing, `lime rebuild xxx` will rebuild inside `.lime`. This ensures every lime project uses its own tools and dependencies. In consequence, it is now possible to rebuild tools and ndll files with lix, using different library versions from a project to another, and without rebuilding everything every time you switch projects. 
- haxe, haxelib and neko command calls have been changed to allow them not being executables. 

### Things to be done / thought:
- [ ] test with the ci.
- [ ] test scoped projects with the ci.
- [ ] add `.lime/settings.json` or similar for scope info in version control, and automatically restore the scope with `lime scope rebuild` (or with `lime setup`?). This might come in another PR.
- [ ] anything else?

