### PR TITLE
Remove outdated line from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Installation
 
 First install the latest version of [Haxe](http://www.haxe.org/download).
 
-The current version of Lime has not been released on haxelib, yet, so please install the latest [development build](http://builds.openfl.org).
-
 
 Development Builds
 ==================


### PR DESCRIPTION
...at least I'm assuming that it's outdated, since this seems to have made it to the readme on Haxelib, which can be rather confusing for users:

https://lib.haxe.org/p/lime/