### PR TITLE
Fix off by one when finding HaxeObject; JNI string

### DIFF
--- a/project/src/system/JNI.cpp
+++ b/project/src/system/JNI.cpp
@@ -931,7 +931,7 @@ namespace lime {
 
 					outType = JNIType (jniObjectString, inDepth);
 
-				} else if (!strncmp(src,"org/haxe/lime/HaxeObject;", 24)) {
+				} else if (!strncmp(src,"org/haxe/lime/HaxeObject;", 25)) {
 
 					outType = JNIType (jniObjectHaxe, inDepth);
 


### PR DESCRIPTION
This PR fixes an off by one in `strncmp(src,"org/haxe/lime/HaxeObject;", 24)` call. The string literal `"org/haxe/lime/HaxeObject;"` has a length of 25 and so the current implementation would also match e.g. `"org/haxe/lime/HaxeObjectSOMETHING;"` strings.