### PR TITLE
fix rebuild iOS due to bad Zlib.cpp path

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -281,7 +281,6 @@
 			<compilerflag value="-DSTATIC_LINK" if="emscripten" />
 			<compilerflag value="-DLIME_ZLIB" />
 
-			<file name="${HXCPP}/project/libs/zlib/ZLib.cpp" if="emscripten || ios || static_link || tvos" />
 			<file name="src/utils/compress/Zlib.cpp" />
 
 		</section>


### PR DESCRIPTION
This file no longer exists in hxcpp. `lime rebuild ios` works correctly without the removed line.