### PR TITLE
Fix for lime build won't read .build if git is present

### DIFF
--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -1247,12 +1247,12 @@ class CommandLineTools
 	{
 		var buildNumber = project.meta.buildNumber;
 
-		if (buildNumber == null || StringTools.startsWith(buildNumber, "git"))
+		if (buildNumber == null && StringTools.startsWith(buildNumber, "git"))
 		{
 			buildNumber = getBuildNumber_GIT(project, increment);
 		}
 
-		if (buildNumber == null || StringTools.startsWith(buildNumber, "svn"))
+		if (buildNumber == null && StringTools.startsWith(buildNumber, "svn"))
 		{
 			buildNumber = getBuildNumber_SVN(project, increment);
 		}


### PR DESCRIPTION
This fixes issue #1409.