### PR TITLE
Fix Std.is() deprecation warnings with Haxe 4.2

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
+++ b/src/lime/_internal/backend/html5/HTML5HTTPRequest.hx
@@ -81,7 +81,7 @@ class HTML5HTTPRequest
 			{
 				if (query.length > 0) query += "&";
 				var value:Dynamic = parent.formData.get(key);
-				if (key.indexOf("[]") > -1 && Std.is(value, Array))
+				if (key.indexOf("[]") > -1 && (value is Array))
 				{
 					var arrayValue:String = Lambda.map(value, function(v:String)
 					{

--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -114,7 +114,7 @@ class HTML5Window
 
 		parent.id = windowID++;
 
-		if (Std.is(element, CanvasElement))
+		if ((element is CanvasElement))
 		{
 			canvas = cast element;
 		}

--- a/src/lime/graphics/ImageBuffer.hx
+++ b/src/lime/graphics/ImageBuffer.hx
@@ -201,11 +201,11 @@ class ImageBuffer
 	@:noCompletion private function set_src(value:Dynamic):Dynamic
 	{
 		#if (js && html5)
-		if (Std.is(value, HTMLImage))
+		if ((value is HTMLImage))
 		{
 			__srcImage = cast value;
 		}
-		else if (Std.is(value, CanvasElement))
+		else if ((value is CanvasElement))
 		{
 			__srcCanvas = cast value;
 			__srcContext = cast __srcCanvas.getContext("2d");

--- a/src/lime/system/System.hx
+++ b/src/lime/system/System.hx
@@ -84,7 +84,7 @@ class System
 		{
 			var htmlElement:Element = null;
 
-			if (Std.is(element, String))
+			if ((element is String))
 			{
 				htmlElement = cast Browser.document.getElementById(element);
 			}
@@ -115,7 +115,7 @@ class System
 
 			if (config == null) config = {};
 
-			if (Reflect.hasField(config, "background") && Std.is(config.background, String))
+			if (Reflect.hasField(config, "background") && (config.background is String))
 			{
 				var background = StringTools.replace(Std.string(config.background), "#", "");
 

--- a/src/lime/tools/AssetHelper.hx
+++ b/src/lime/tools/AssetHelper.hx
@@ -49,7 +49,7 @@ class AssetHelper
 				{
 					File.saveBytes(destination, Base64.decode(asset.data));
 				}
-				else if (Std.is(asset.data, HaxeBytes))
+				else if ((asset.data is HaxeBytes))
 				{
 					File.saveBytes(destination, cast asset.data);
 				}
@@ -86,7 +86,7 @@ class AssetHelper
 				{
 					File.saveBytes(destination, Base64.decode(asset.data));
 				}
-				else if (Std.is(asset.data, HaxeBytes))
+				else if ((asset.data is HaxeBytes))
 				{
 					File.saveBytes(destination, cast asset.data);
 				}

--- a/src/lime/tools/FlashHelper.hx
+++ b/src/lime/tools/FlashHelper.hx
@@ -499,7 +499,7 @@ class FlashHelper
 				{
 					bytes = Base64.decode(inAsset.data);
 				}
-				else if (Std.is(inAsset.data, Bytes))
+				else if ((inAsset.data is Bytes))
 				{
 					bytes = cast inAsset.data;
 				}
@@ -807,7 +807,7 @@ class FlashHelper
 					{
 						File.saveBytes(sourcePath, Base64.decode(asset.data));
 					}
-					else if (Std.is(asset.data, Bytes))
+					else if ((asset.data is Bytes))
 					{
 						File.saveBytes(sourcePath, asset.data);
 					}

--- a/src/lime/utils/ArrayBuffer.hx
+++ b/src/lime/utils/ArrayBuffer.hx
@@ -24,7 +24,7 @@ abstract ArrayBuffer(Bytes) from Bytes to Bytes
 
 	public static inline function isView(arg:Dynamic):Bool
 	{
-		return (arg != null && Std.is(arg, ArrayBufferView));
+		return (arg != null && (arg is ArrayBufferView));
 	}
 
 	public inline function slice(begin:Int, end:Null<Int> = null)

--- a/src/lime/utils/AssetCache.hx
+++ b/src/lime/utils/AssetCache.hx
@@ -62,12 +62,12 @@ class AssetCache
 				font.set(id, asset);
 
 			case IMAGE:
-				if (!Std.is(asset, Image)) throw "Cannot cache non-Image asset: " + asset + " as Image";
+				if (!(asset is Image)) throw "Cannot cache non-Image asset: " + asset + " as Image";
 
 				image.set(id, asset);
 
 			case SOUND, MUSIC:
-				if (!Std.is(asset, AudioBuffer)) throw "Cannot cache non-AudioBuffer asset: " + asset + " as AudioBuffer";
+				if (!(asset is AudioBuffer)) throw "Cannot cache non-AudioBuffer asset: " + asset + " as AudioBuffer";
 
 				audio.set(id, asset);
 

--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -1860,15 +1860,15 @@ class CommandLineTools
 
 					if (Reflect.hasField(fieldValue, attribute))
 					{
-						if (Std.is(Reflect.field(fieldValue, attribute), String))
+						if ((Reflect.field(fieldValue, attribute) is String))
 						{
 							Reflect.setField(fieldValue, attribute, projectDefines.get(key));
 						}
-						else if (Std.is(Reflect.field(fieldValue, attribute), Float))
+						else if ((Reflect.field(fieldValue, attribute) is Float))
 						{
 							Reflect.setField(fieldValue, attribute, Std.parseFloat(projectDefines.get(key)));
 						}
-						else if (Std.is(Reflect.field(fieldValue, attribute), Bool))
+						else if ((Reflect.field(fieldValue, attribute) is Bool))
 						{
 							Reflect.setField(fieldValue, attribute, (projectDefines.get(key).toLowerCase() == "true"
 								|| projectDefines.get(key) == "1"));
@@ -2121,19 +2121,19 @@ class CommandLineTools
 						{
 							var propertyReference = Reflect.field(fieldReference, property);
 
-							if (Std.is(propertyReference, Bool))
+							if ((propertyReference is Bool))
 							{
 								Reflect.setField(fieldReference, property, argValue == "true");
 							}
-							else if (Std.is(propertyReference, Int))
+							else if ((propertyReference is Int))
 							{
 								Reflect.setField(fieldReference, property, Std.parseInt(argValue));
 							}
-							else if (Std.is(propertyReference, Float))
+							else if ((propertyReference is Float))
 							{
 								Reflect.setField(fieldReference, property, Std.parseFloat(argValue));
 							}
-							else if (Std.is(propertyReference, String))
+							else if ((propertyReference is String))
 							{
 								Reflect.setField(fieldReference, property, argValue);
 							}


### PR DESCRIPTION
`Std.is()` has been deprecated in Haxe 4.2: https://github.com/HaxeFoundation/haxe/commit/8ef3be1ae80fe4361572100fe7988518bc59c9ed

Rather than using `Std.isOfType()`, it's cleaner to use the `is` syntax with mandatory parens if possible* - it's already available since Haxe 3.4, so it doesn't require conditional compilation (afaik that's the oldest version still supported by OpenFL anyway).

<sup>*possible whenever the RHS is a type rather than an expression</sup>