### PR TITLE
Add flag to read buildNumber from .build.

### DIFF
--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -1257,7 +1257,7 @@ class CommandLineTools
 			buildNumber = getBuildNumber_SVN(project, increment);
 		}
 
-		if (buildNumber == null)
+		if (buildNumber == null || buildNumber == ".build")
 		{
 			var versionFile = Path.combine(project.app.path, ".build");
 			var version = 1;


### PR DESCRIPTION
By setting `<meta build-number=".build" />`, you can force Lime not to calculate a build number from git or svn, but instead use the default option of getting it from the .build file.

Since setting this value would previously have produced useless build numbers, it's unlikely that this affects any existing builds.

This should fix #1409 without causing #1414 to happen again.