### PR TITLE
Fixes #1409 and prevents #1414

### DIFF
--- a/tools/CommandLineTools.hx
+++ b/tools/CommandLineTools.hx
@@ -1247,16 +1247,6 @@ class CommandLineTools
 	{
 		var buildNumber = project.meta.buildNumber;
 
-		if (buildNumber == null || StringTools.startsWith(buildNumber, "git"))
-		{
-			buildNumber = getBuildNumber_GIT(project, increment);
-		}
-
-		if (buildNumber == null || StringTools.startsWith(buildNumber, "svn"))
-		{
-			buildNumber = getBuildNumber_SVN(project, increment);
-		}
-
 		if (buildNumber == null)
 		{
 			var versionFile = Path.combine(project.app.path, ".build");
@@ -1295,6 +1285,14 @@ class CommandLineTools
 				}
 				catch (e:Dynamic) {}
 			}
+		}
+		else if (StringTools.startsWith(buildNumber, "git"))
+		{
+			buildNumber = getBuildNumber_GIT(project, increment);
+		}
+		else if (StringTools.startsWith(buildNumber, "svn"))
+		{
+			buildNumber = getBuildNumber_SVN(project, increment);
 		}
 	}
 


### PR DESCRIPTION
I gave a look at the git history of the piece of code that computes the build number; this PR is based on the following interpretation of what the default behaviour of `lime build` should be:
- if `meta build-number` is not set, then it should read the `.build` file and, if missing, it should create it;
- if `meta build-number` is set to "git*", then it should calculate the build number from `git rev-list`;
- if `meta build-number` is set to "svn*", then it should calculate the build number from svn revision number;
- if `meta build-number` is set to something else, then it should use this as the build number.

The code, currently, does this:
- if `meta build-number` is not set, the build number will be calculated from git;
- if `meta build-number` is not set and git is not found, the build number will be calculated  from svn;
- if `meta build-number` is not set and neither git nor svn are found, the build number will be read from the `.build` file;
- if `meta build-number` is set to "git*", the build number will be calculated from git;
- if `meta build-number` is set to "svn*", the build number will be calculated from svn;
- if `meta build-number` is set to "whatever", the build number will be "whatever".

The code is changed in this way:
- first, checks if the buildNumber is null (i.e. the meta build-number is not set in the project config);
- if `buildNumber` is null it reads the `.build` file and creates it if it's missing;
- else if `buildNumber` is a string starting with "git", it calls the git version of getBuildNumber;
- else if `buildNumber` is a string starting with "svn", it calls the svn version of getBuildNumber

What should happen:
- `meta build-number` is not set -> `.build` file;
- `meta build-number` set to "git*" -> git rev;
- `meta build-number` set to "svn*" -> svn rev;
- `meta build-number` set to "whatever" -> "whatever".

Fixes #1409, prevents #1414; supersedes #1410 and #1417.