### PR TITLE
Hl setup

### DIFF
--- a/tools/platforms/WindowsPlatform.hx
+++ b/tools/platforms/WindowsPlatform.hx
@@ -204,6 +204,16 @@ class WindowsPlatform extends PlatformTarget
 					{
 						ProjectHelper.copyLibrary(project, ndll, "Windows" + (is64 ? "64" : ""), "", ".hdll", applicationDirectory, project.debug,
 							targetSuffix);
+							
+						if (!project.environment.exists("HL_PATH"))
+						{
+							var command = #if lime "lime" #else "hxp" #end;
+
+							Log.info("You must define HL_PATH to copy HL dependencies: '" + command + " setup hl' first");
+							
+						}else{
+							System.copyFile(project.environment.get("HL_PATH") + '/ssl.hdll', applicationDirectory + '/ssl.hdll');
+						}
 					}
 					else
 					{

--- a/tools/utils/PlatformSetup.hx
+++ b/tools/utils/PlatformSetup.hx
@@ -24,6 +24,7 @@ class PlatformSetup
 	private static var linuxPacman32Packages = "multilib-devel mesa mesa-libgl glu";
 	private static var linuxPacman64Packages = "multilib-devel lib32-mesa lib32-mesa-libgl lib32-glu";
 	private static var visualStudioURL = "https://www.visualstudio.com/downloads/";
+	private static var hashlinkURL = "https://github.com/HaxeFoundation/hashlink/releases";
 	private static var triedSudo:Bool = false;
 	private static var userDefines:Map<String, Dynamic>;
 	private static var targetFlags:Map<String, Dynamic>;
@@ -410,8 +411,11 @@ class PlatformSetup
 						setupWindows();
 					}
 
-				case "neko", "hl", "hashlink", "cs", "uwp", "winjs", "nodejs", "java":
+				case "neko", "cs", "uwp", "winjs", "nodejs", "java":
 					Log.println("\x1b[0;3mNo additional configuration is required.\x1b[0m");
+				
+				case "hl", "hashlink":
+					setupHL();
 
 				case "lime":
 					setupLime();
@@ -1178,6 +1182,28 @@ class PlatformSetup
 		{
 			System.openURL(visualStudioURL);
 		}
+	}
+	
+	public static function setupHL():Void
+	{
+		Log.println("\x1b[1mIn order to build HashLink executables you must have");
+		Log.println("HashLink binaries installed.");
+		Log.println("We recommend using version \"1.10.0\"");
+		Log.println("available as a free download from Github.\x1b[0m");
+		
+		
+
+		var answer = CLIHelper.ask("Would you like to visit the download page now?");
+
+		if (answer == YES || answer == ALWAYS)
+		{
+			System.openURL(hashlinkURL);
+			
+		}
+		
+		getDefineValue("HL_PATH", "Path to Hashlink binaries.");
+		Log.println("");
+		Log.println("Setup completed");
 	}
 
 	private static function throwPermissionsError()


### PR DESCRIPTION
This PR adds the ability to set up where the HashLink binaries are with `lime setup hl`.
Then it copies **ssl.hdll** from hashlink binaries to bin folder with `lime build hl`. If binaries aren't found, this file is not copied but build process continues.

I've made this feature because one of my project needs ssl.hdll for some reason (I don't know why honestly).

In the future we will be able to copy every .hdll files needed for a project but for now it's a good start.