### PR TITLE
Fix CI edge case

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,7 @@ jobs:
       run: |
         haxelib dev lime $GITHUB_WORKSPACE
         haxelib run lime setup -alias -y
+        lime || alias lime="haxelib run lime"
 
     - name: Install "lime" command alias (Windows)
       if: ${{ startsWith(matrix.os, 'windows-') }}


### PR DESCRIPTION
Depending on how the CI server is set up, the task may fail to create the `lime` command. For instance, #1416 returned failure due to dependabot's settings, not due to the contents of the pull request.

This commit provides a simple workaround for those cases, running only if `lime setup -alias` fails. It shouldn't have any effect in cases that already work.