### PR TITLE
Improve the error message for an unsupported use case

### DIFF
--- a/include.xml
+++ b/include.xml
@@ -3,6 +3,8 @@
 
 	<log error="Lime ${lime} is not compatible with Haxe ${haxe} (version 3.2.0 or higher is required)" if="${haxe < 3.2.0}" />
 
+	<log error="Lime ${lime} requires Haxe 4 to target HashLink (version ${haxe} found)" if="hl ${${haxe} < 4.0}" />
+
 	<set name="lime" />
 
 	<define name="native" if="cpp || neko || nodejs || cs || java || hl" />


### PR DESCRIPTION
Lime requires the `Deque` class to target HashLink, which only became available in Haxe 4. If you try, Lime should at least let you know what's wrong.

Helps address #1403.