### PR TITLE
Fix for android screen orientation

### DIFF
--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -10,7 +10,9 @@
 	<uses-sdk android:minSdkVersion="::ANDROID_MINIMUM_SDK_VERSION::" android:targetSdkVersion="::ANDROID_TARGET_SDK_VERSION::"/>
 	
 	<application android:label="::APP_TITLE::" ::if (HAS_ICON):: android:icon="@drawable/icon"::end:: android:allowBackup="true" android:theme="@android:style/Theme.NoTitleBar::if (WIN_FULLSCREEN)::.Fullscreen::end::" android:hardwareAccelerated="true">
-		
+
+		<meta-data android:name="SDL_ENV.SDL_IOS_ORIENTATIONS" android:value= ::if (WIN_ORIENTATION=="portrait"):: "Portrait PortraitUpsideDown" ::end::::if (WIN_ORIENTATION=="landscape"):: "LandscapeLeft LandscapeRight" ::end:: />
+
 		<activity android:name="MainActivity" android:launchMode="singleTask" android:label="::APP_TITLE::" android:configChanges="keyboardHidden|orientation|screenSize|screenLayout"::if (WIN_ORIENTATION=="portrait"):: android:screenOrientation="sensorPortrait"::end::::if (WIN_ORIENTATION=="landscape"):: android:screenOrientation="sensorLandscape"::end::>
 			
 			<intent-filter>

--- a/templates/android/template/app/src/main/AndroidManifest.xml
+++ b/templates/android/template/app/src/main/AndroidManifest.xml
@@ -11,7 +11,13 @@
 	
 	<application android:label="::APP_TITLE::" ::if (HAS_ICON):: android:icon="@drawable/icon"::end:: android:allowBackup="true" android:theme="@android:style/Theme.NoTitleBar::if (WIN_FULLSCREEN)::.Fullscreen::end::" android:hardwareAccelerated="true">
 
-		<meta-data android:name="SDL_ENV.SDL_IOS_ORIENTATIONS" android:value= ::if (WIN_ORIENTATION=="portrait"):: "Portrait PortraitUpsideDown" ::end::::if (WIN_ORIENTATION=="landscape"):: "LandscapeLeft LandscapeRight" ::end:: />
+		::if (WIN_ORIENTATION=="portrait")::
+		<meta-data android:name="SDL_ENV.SDL_IOS_ORIENTATIONS" android:value=  "Portrait PortraitUpsideDown" />
+		::end::
+
+		::if (WIN_ORIENTATION=="landscape")::
+		<meta-data android:name="SDL_ENV.SDL_IOS_ORIENTATIONS" android:value=  "LandscapeLeft LandscapeRight" />
+		::end::
 
 		<activity android:name="MainActivity" android:launchMode="singleTask" android:label="::APP_TITLE::" android:configChanges="keyboardHidden|orientation|screenSize|screenLayout"::if (WIN_ORIENTATION=="portrait"):: android:screenOrientation="sensorPortrait"::end::::if (WIN_ORIENTATION=="landscape"):: android:screenOrientation="sensorLandscape"::end::>
 			


### PR DESCRIPTION
This should fix the problem where Android apps would rotate to any direction even though the window orientation  was specified.

and yes it actually says `IOS` in `SDL_ENV.SDL_IOS_ORIENTATIONS` but that's what the  SDL define says.

```
/**
 *  \brief  A variable controlling which orientations are allowed on iOS/Android.
 *
 *  In some circumstances it is necessary to be able to explicitly control
 *  which UI orientations are allowed.
 *
 *  This variable is a space delimited list of the following values:
 *    "LandscapeLeft", "LandscapeRight", "Portrait" "PortraitUpsideDown"
 */
#define SDL_HINT_ORIENTATIONS "SDL_IOS_ORIENTATIONS"
```