### PR TITLE
Fix audio stutter on HTML5

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5AudioSource.hx
+++ b/src/lime/_internal/backend/html5/HTML5AudioSource.hx
@@ -54,7 +54,13 @@ class HTML5AudioSource
 
 		parent.buffer.__srcHowl.on("end", howl_onEnd, id);
 
+		// Calling setCurrentTime causes html5 audio to replay from this position on next frame
+		#if force_html5_audio
+		if(time == 0) setCurrentTime(time);
+		#else
 		setCurrentTime(time);
+		#end
+
 		#end
 	}
 


### PR DESCRIPTION
Patches an issue causing audio to play twice if force_html_audio is enabled. This appears to be an oversight with Howl.