### PR TITLE
Add failIfMajorPerformanceCaveat setting

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -287,7 +287,7 @@ class HTML5Window
 						premultipliedAlpha: true,
 						stencil: Reflect.hasField(contextAttributes, "stencil") ? contextAttributes.stencil : false,
 						preserveDrawingBuffer: false,
-						failIfMajorPerformanceCaveat: true
+						failIfMajorPerformanceCaveat: Reflect.hasField(contextAttributes, "failIfMajorPerformanceCaveat") ? contextAttributes.failIfMajorPerformanceCaveat : false,
 					};
 
 				var glContextType = ["webgl", "experimental-webgl"];

--- a/src/lime/graphics/RenderContextAttributes.hx
+++ b/src/lime/graphics/RenderContextAttributes.hx
@@ -48,4 +48,10 @@ typedef RenderContextAttributes =
 		Whether vertical-sync (VSync) is enabled
 	**/
 	@:optional var vsync:Bool;
+	
+	/**
+		Boolean that indicates if a context will be created 
+		if the system performance is low or if no hardware GPU is available
+	**/
+	@:optional var failIfMajorPerformanceCaveat:Bool;
 }

--- a/src/lime/system/System.hx
+++ b/src/lime/system/System.hx
@@ -509,6 +509,8 @@ class System
 							attributes.x = Std.parseInt(argValue);
 						case "y":
 							attributes.y = Std.parseInt(argValue);
+						case "failIfMajorPerformanceCaveat":
+							attributes.context.failIfMajorPerformanceCaveat = __parseBool(argValue);
 						default:
 					}
 				}

--- a/src/lime/tools/HXProject.hx
+++ b/src/lime/tools/HXProject.hx
@@ -171,6 +171,7 @@ class HXProject extends Script
 				depthBuffer: true,
 				stencilBuffer: true,
 				colorDepth: 32,
+				failIfMajorPerformanceCaveat: false,
 				maximized: false,
 				minimized: false,
 				hidden: false,

--- a/src/lime/tools/WindowData.hx
+++ b/src/lime/tools/WindowData.hx
@@ -23,6 +23,7 @@ typedef WindowData =
 	@:optional var requireShaders:Bool;
 	@:optional var depthBuffer:Bool;
 	@:optional var stencilBuffer:Bool;
+	@:optional var failIfMajorPerformanceCaveat:Bool;
 	@:optional var title:String;
 	#if (js && html5)
 	@:optional var element:js.html.Element;

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -60,6 +60,7 @@ import ::APP_MAIN::;
 				depth: ::depthBuffer::,
 				hardware: ::hardware::,
 				stencil: ::stencilBuffer::,
+				failIfMajorPerformanceCaveat: ::failIfMajorPerformanceCaveat::,
 				type: null,
 				vsync: ::vsync::
 			};


### PR DESCRIPTION
Recent update of Google Chrome has changed behavior of `failIfMajorPerformanceCaveat` option for creation of WebGL context - it fails more frequently for old videocards.
This change add setting for `failIfMajorPerformanceCaveat`, which is `false` by default now, but you could change it with "project.xml" or "project.hx" files by adding attribute `failIfMajorPerformanceCaveat` to the window