### PR TITLE
remove garbage from bytes when saving a file on html5

### DIFF
--- a/src/lime/ui/FileDialog.hx
+++ b/src/lime/ui/FileDialog.hx
@@ -223,6 +223,7 @@ class FileDialog
 
 		var path = defaultPath != null ? Path.withoutDirectory(defaultPath) : "download" + defaultExtension;
 		var buffer = (data : Bytes).getData();
+		buffer = buffer.slice(0, (data:Bytes).length);
 
 		#if commonjs
 		untyped #if haxe4 js.Syntax.code #else __js__ #end("require ('file-saver')")(new Blob([buffer], {type: type}), path, true);


### PR DESCRIPTION
see https://community.openfl.org/t/problem-with-filereference-save-xml/12776/2

fix : https://github.com/openfl/openfl/issues/2423