### PR TITLE
Use existing "workingDirectory" value instead of re-calculating.

### DIFF
--- a/src/lime/tools/ProjectHelper.hx
+++ b/src/lime/tools/ProjectHelper.hx
@@ -111,6 +111,10 @@ class ProjectHelper
 		{
 			return project.environment.get(string);
 		}
+		else if (string == "projectDirectory")
+		{
+			return project.workingDirectory;
+		}
 		else
 		{
 			var substring = StringTools.replace(string, " ", "");
@@ -174,14 +178,6 @@ class ProjectHelper
 					}
 				}
 			}
-			#if sys
-			else if (substring == "projectDirectory")
-			{
-				// TODO: Better handling if CWD has changed?
-
-				return Std.string(Sys.getCwd());
-			}
-			#end
 		}
 
 		return string;


### PR DESCRIPTION
Now that `project.workingDirectory` exists, we may as well use it.

In the future, we might change this line to `if (string == "projectDirectory" || string == "workingDirectory")` because the latter matches the variable name, and it's nice to have consistent naming conventions. For now I decided to make the minimum number of changes.