### PR TITLE
Feature/haxe 4 2 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Haxe dependencies
         run: |
-          haxelib install hxcpp 4.0.64 --quiet
+          haxelib install hxcpp 4.2.1 --quiet
           haxelib install format  --quiet
           haxelib install hxp  --quiet
           haxelib git lime-samples https://github.com/openfl/lime-samples --quiet
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install Haxe dependencies
         run: |
-          haxelib install hxcpp 4.0.64 --quiet
+          haxelib install hxcpp 4.2.1 --quiet
           haxelib install format  --quiet
           haxelib install hxp  --quiet
           haxelib git lime-samples https://github.com/openfl/lime-samples --quiet
@@ -145,7 +145,7 @@ jobs:
 
       - name: Install Haxe dependencies
         run: |
-          haxelib install hxcpp 4.0.64 --quiet
+          haxelib install hxcpp 4.2.1 --quiet
           haxelib install format  --quiet
           haxelib install hxp  --quiet
           haxelib git lime-samples https://github.com/openfl/lime-samples --quiet
@@ -202,7 +202,7 @@ jobs:
 
       - name: Install Haxe dependencies
         run: |
-          haxelib install hxcpp 4.0.64 --quiet
+          haxelib install hxcpp 4.2.1 --quiet
           haxelib install format  --quiet
           haxelib install hxp  --quiet
           haxelib git lime-samples https://github.com/openfl/lime-samples --quiet
@@ -308,7 +308,7 @@ jobs:
 
       - name: Install Haxe dependencies
         run: |
-          haxelib install hxcpp 4.0.64 --quiet
+          haxelib install hxcpp 4.2.1 --quiet
           haxelib install format  --quiet
           haxelib install hxp  --quiet
           haxelib git lime-samples https://github.com/openfl/lime-samples --quiet
@@ -358,7 +358,7 @@ jobs:
 
       - name: Install Haxe dependencies
         run: |
-          haxelib install hxcpp 4.0.64 --quiet
+          haxelib install hxcpp 4.2.1 --quiet
           haxelib install format  --quiet
           haxelib install hxp  --quiet
           haxelib git lime-samples https://github.com/openfl/lime-samples --quiet
@@ -415,7 +415,7 @@ jobs:
 
       - name: Install Haxe dependencies
         run: |
-          haxelib install hxcpp 4.0.64 --quiet
+          haxelib install hxcpp 4.2.1 --quiet
           haxelib install format  --quiet
           haxelib install hxp  --quiet
           haxelib git lime-samples https://github.com/openfl/lime-samples --quiet
@@ -484,7 +484,7 @@ jobs:
 
     - name: Install Haxe dependencies
       run: |
-        haxelib install hxcpp 4.0.64 --quiet
+        haxelib install hxcpp 4.2.1 --quiet
         haxelib install format  --quiet
         haxelib install hxp  --quiet
         haxelib git lime-samples https://github.com/openfl/lime-samples --quiet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: haxeui/haxeui-core/.github/actions/haxe@master
         with:
-          haxe-version: 4.1.5
+          haxe-version: 4.2.0
 
       - uses: actions/setup-java@v1
         with:
@@ -87,7 +87,7 @@ jobs:
 
       - uses: haxeui/haxeui-core/.github/actions/haxe@master
         with:
-          haxe-version: 4.1.5
+          haxe-version: 4.2.0
 
       - name: Install system dependencies
         run: |
@@ -136,7 +136,7 @@ jobs:
 
       - uses: haxeui/haxeui-core/.github/actions/haxe@master
         with:
-          haxe-version: 4.1.5
+          haxe-version: 4.2.0
 
       - name: Install system dependencies (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
@@ -194,7 +194,7 @@ jobs:
 
       - uses: haxeui/haxeui-core/.github/actions/haxe@master
         with:
-          haxe-version: 4.1.5
+          haxe-version: 4.2.0
 
       - name: Install system dependencies
         run: |
@@ -246,7 +246,7 @@ jobs:
 
       - uses: haxeui/haxeui-core/.github/actions/haxe@master
         with:
-          haxe-version: 4.1.5
+          haxe-version: 4.2.0
 
       - name: Install Haxe dependencies
         run: |
@@ -300,7 +300,7 @@ jobs:
 
       - uses: haxeui/haxeui-core/.github/actions/haxe@master
         with:
-          haxe-version: 4.1.5
+          haxe-version: 4.2.0
 
       - name: Install system dependencies
         run: |
@@ -354,7 +354,7 @@ jobs:
 
       - uses: haxeui/haxeui-core/.github/actions/haxe@master
         with:
-          haxe-version: 4.1.5
+          haxe-version: 4.2.0
 
       - name: Install Haxe dependencies
         run: |
@@ -406,7 +406,7 @@ jobs:
 
       - uses: haxeui/haxeui-core/.github/actions/haxe@master
         with:
-          haxe-version: 4.1.5
+          haxe-version: 4.2.0
 
       - name: Install system dependencies (Linux)
         if: ${{ startsWith(matrix.os, 'ubuntu-') }}
@@ -480,7 +480,7 @@ jobs:
 
     - uses: haxeui/haxeui-core/.github/actions/haxe@master
       with:
-        haxe-version: 4.1.5
+        haxe-version: 4.2.0
 
     - name: Install Haxe dependencies
       run: |

--- a/src/lime/_internal/graphics/ImageDataUtil.hx
+++ b/src/lime/_internal/graphics/ImageDataUtil.hx
@@ -864,8 +864,8 @@ class ImageDataUtil
 			var dataView = new ImageDataView(image, rect);
 			var position;
 			var argb:ARGB = new RGBA();
-			var bgra:BGRA = new RGBA();
-			var pixel:RGBA= new RGBA();
+			var bgra:BGRA = new BGRA();
+			var pixel:RGBA = new RGBA();
 			var destPosition = 0;
 
 			for (y in 0...dataView.height)

--- a/src/lime/_internal/graphics/ImageDataUtil.hx
+++ b/src/lime/_internal/graphics/ImageDataUtil.hx
@@ -50,19 +50,19 @@ class ImageDataUtil
 
 		var sourceOffset:Int;
 
-		var sourcePixel:RGBA;
-		var mapPixel:RGBA;
-		var targetPixel:RGBA;
+		var sourcePixel:RGBA = new RGBA();
+		var mapPixel:RGBA = new RGBA();
+		var targetPixel:RGBA = new RGBA();
 
 		var mapPixelX:Float;
 		var mapPixelY:Float;
 		var mapPixelA:Float;
 
 		// for bilinear smoothing
-		var s1:RGBA;
-		var s2:RGBA;
-		var s3:RGBA;
-		var s4:RGBA;
+		var s1:RGBA = new RGBA();
+		var s2:RGBA = new RGBA();
+		var s3:RGBA = new RGBA();
+		var s4:RGBA = new RGBA();
 
 		var mPointXFloor:Int;
 		var mPointYFloor:Int;
@@ -180,7 +180,7 @@ class ImageDataUtil
 			var greenTable = colorMatrix.getGreenTable();
 			var blueTable = colorMatrix.getBlueTable();
 
-			var row, offset, pixel:RGBA;
+			var row, offset, pixel:RGBA = new RGBA();
 
 			for (y in 0...dataView.height)
 			{
@@ -240,8 +240,8 @@ class ImageDataUtil
 
 			var srcPosition,
 				destPosition,
-				srcPixel:RGBA,
-				destPixel:RGBA,
+				srcPixel:RGBA = new RGBA(),
+				destPixel:RGBA = new RGBA(),
 				value = 0;
 
 			for (y in 0...destView.height)
@@ -329,7 +329,8 @@ class ImageDataUtil
 
 				var sourcePosition, destPosition;
 				var sourceAlpha, destAlpha, oneMinusSourceAlpha, blendAlpha;
-				var sourcePixel:RGBA, destPixel:RGBA;
+				var sourcePixel:RGBA = new RGBA();
+				var destPixel:RGBA = new RGBA();
 
 				var sourcePremultiplied = sourceImage.buffer.premultiplied;
 				var destPremultiplied = image.buffer.premultiplied;
@@ -423,7 +424,7 @@ class ImageDataUtil
 				{
 					var alphaData = alphaImage.buffer.data;
 					var alphaFormat = alphaImage.buffer.format;
-					var alphaPosition, alphaPixel:RGBA;
+					var alphaPosition, alphaPixel:RGBA = new RGBA();
 
 					var alphaView = new ImageDataView(alphaImage,
 						new Rectangle(sourceView.x + (alphaPoint == null ? 0 : alphaPoint.x), sourceView.y + (alphaPoint == null ? 0 : alphaPoint.y),
@@ -571,7 +572,7 @@ class ImageDataUtil
 
 			var fillColor:RGBA = color;
 
-			var hitColor:RGBA;
+			var hitColor:RGBA = new RGBA();
 			hitColor.readUInt8(data, ((y + image.offsetY) * (image.buffer.width * 4)) + ((x + image.offsetX) * 4), format, premultiplied);
 
 			if (!image.transparent)
@@ -601,7 +602,7 @@ class ImageDataUtil
 				nextPointX,
 				nextPointY,
 				nextPointOffset,
-				readColor:RGBA;
+				readColor:RGBA = new RGBA();
 
 			while (queue.length > 0)
 			{
@@ -809,7 +810,7 @@ class ImageDataUtil
 
 	public static function getPixel(image:Image, x:Int, y:Int, format:PixelFormat):Int
 	{
-		var pixel:RGBA;
+		var pixel:RGBA = new RGBA();
 
 		pixel.readUInt8(image.buffer.data, (4 * (y + image.offsetY) * image.buffer.width + (x + image.offsetX) * 4), image.buffer.format,
 			image.buffer.premultiplied);
@@ -828,7 +829,7 @@ class ImageDataUtil
 
 	public static function getPixel32(image:Image, x:Int, y:Int, format:PixelFormat):Int
 	{
-		var pixel:RGBA;
+		var pixel:RGBA = new RGBA();
 
 		pixel.readUInt8(image.buffer.data, (4 * (y + image.offsetY) * image.buffer.width + (x + image.offsetX) * 4), image.buffer.format,
 			image.buffer.premultiplied);
@@ -861,7 +862,10 @@ class ImageDataUtil
 			var premultiplied = image.buffer.premultiplied;
 
 			var dataView = new ImageDataView(image, rect);
-			var position, argb:ARGB, bgra:BGRA, pixel:RGBA;
+			var position;
+			var argb:ARGB = new RGBA();
+			var bgra:BGRA = new RGBA();
+			var pixel:RGBA= new RGBA();
 			var destPosition = 0;
 
 			for (y in 0...dataView.height)
@@ -917,7 +921,9 @@ class ImageDataUtil
 			var sourcePremultiplied = sourceImage.buffer.premultiplied;
 			var destPremultiplied = image.buffer.premultiplied;
 
-			var sourcePosition, destPosition, sourcePixel:RGBA, destPixel:RGBA;
+			var sourcePosition, destPosition;
+			var sourcePixel:RGBA = new RGBA();
+			var destPixel:RGBA = new RGBA();
 
 			for (y in 0...destView.height)
 			{
@@ -958,7 +964,7 @@ class ImageDataUtil
 		{
 			var format = image.buffer.format;
 			var length = Std.int(data.length / 4);
-			var pixel:RGBA;
+			var pixel:RGBA = new RGBA();
 
 			for (i in 0...length)
 			{
@@ -1341,8 +1347,8 @@ class ImageDataUtil
 
 			var srcPosition,
 				destPosition,
-				srcPixel:RGBA,
-				destPixel:RGBA,
+				srcPixel:RGBA  = new RGBA(),
+				destPixel:RGBA  = new RGBA(),
 				pixelMask:UInt,
 				test:Bool,
 				value:Int;
@@ -1408,7 +1414,7 @@ class ImageDataUtil
 		{
 			var format = image.buffer.format;
 			var length = Std.int(data.length / 4);
-			var pixel:RGBA;
+			var pixel:RGBA  = new RGBA();
 
 			for (i in 0...length)
 			{

--- a/src/lime/_internal/graphics/ImageDataUtil.hx
+++ b/src/lime/_internal/graphics/ImageDataUtil.hx
@@ -50,19 +50,19 @@ class ImageDataUtil
 
 		var sourceOffset:Int;
 
-		var sourcePixel:RGBA = new RGBA();
-		var mapPixel:RGBA = new RGBA();
-		var targetPixel:RGBA = new RGBA();
+		var sourcePixel:RGBA = 0;
+		var mapPixel:RGBA = 0;
+		var targetPixel:RGBA = 0;
 
 		var mapPixelX:Float;
 		var mapPixelY:Float;
 		var mapPixelA:Float;
 
 		// for bilinear smoothing
-		var s1:RGBA = new RGBA();
-		var s2:RGBA = new RGBA();
-		var s3:RGBA = new RGBA();
-		var s4:RGBA = new RGBA();
+		var s1:RGBA = 0;
+		var s2:RGBA = 0;
+		var s3:RGBA = 0;
+		var s4:RGBA = 0;
 
 		var mPointXFloor:Int;
 		var mPointYFloor:Int;
@@ -141,7 +141,7 @@ class ImageDataUtil
 
 	private static function lerpRGBA(v0:RGBA, v1:RGBA, x:Float):RGBA
 	{
-		var result:RGBA = new RGBA();
+		var result:RGBA = 0;
 		result.r = Math.floor(lerp(v0.r, v1.r, x));
 		result.g = Math.floor(lerp(v0.g, v1.g, x));
 		result.b = Math.floor(lerp(v0.b, v1.b, x));
@@ -180,7 +180,7 @@ class ImageDataUtil
 			var greenTable = colorMatrix.getGreenTable();
 			var blueTable = colorMatrix.getBlueTable();
 
-			var row, offset, pixel:RGBA = new RGBA();
+			var row, offset, pixel:RGBA = 0;
 
 			for (y in 0...dataView.height)
 			{
@@ -240,8 +240,8 @@ class ImageDataUtil
 
 			var srcPosition,
 				destPosition,
-				srcPixel:RGBA = new RGBA(),
-				destPixel:RGBA = new RGBA(),
+				srcPixel:RGBA = 0,
+				destPixel:RGBA = 0,
 				value = 0;
 
 			for (y in 0...destView.height)
@@ -329,8 +329,8 @@ class ImageDataUtil
 
 				var sourcePosition, destPosition;
 				var sourceAlpha, destAlpha, oneMinusSourceAlpha, blendAlpha;
-				var sourcePixel:RGBA = new RGBA();
-				var destPixel:RGBA = new RGBA();
+				var sourcePixel:RGBA = 0;
+				var destPixel:RGBA = 0;
 
 				var sourcePremultiplied = sourceImage.buffer.premultiplied;
 				var destPremultiplied = image.buffer.premultiplied;
@@ -424,7 +424,7 @@ class ImageDataUtil
 				{
 					var alphaData = alphaImage.buffer.data;
 					var alphaFormat = alphaImage.buffer.format;
-					var alphaPosition, alphaPixel:RGBA = new RGBA();
+					var alphaPosition, alphaPixel:RGBA = 0;
 
 					var alphaView = new ImageDataView(alphaImage,
 						new Rectangle(sourceView.x + (alphaPoint == null ? 0 : alphaPoint.x), sourceView.y + (alphaPoint == null ? 0 : alphaPoint.y),
@@ -572,7 +572,7 @@ class ImageDataUtil
 
 			var fillColor:RGBA = color;
 
-			var hitColor:RGBA = new RGBA();
+			var hitColor:RGBA = 0;
 			hitColor.readUInt8(data, ((y + image.offsetY) * (image.buffer.width * 4)) + ((x + image.offsetX) * 4), format, premultiplied);
 
 			if (!image.transparent)
@@ -602,7 +602,7 @@ class ImageDataUtil
 				nextPointX,
 				nextPointY,
 				nextPointOffset,
-				readColor:RGBA = new RGBA();
+				readColor:RGBA = 0;
 
 			while (queue.length > 0)
 			{
@@ -810,7 +810,7 @@ class ImageDataUtil
 
 	public static function getPixel(image:Image, x:Int, y:Int, format:PixelFormat):Int
 	{
-		var pixel:RGBA = new RGBA();
+		var pixel:RGBA = 0;
 
 		pixel.readUInt8(image.buffer.data, (4 * (y + image.offsetY) * image.buffer.width + (x + image.offsetX) * 4), image.buffer.format,
 			image.buffer.premultiplied);
@@ -829,7 +829,7 @@ class ImageDataUtil
 
 	public static function getPixel32(image:Image, x:Int, y:Int, format:PixelFormat):Int
 	{
-		var pixel:RGBA = new RGBA();
+		var pixel:RGBA = 0;
 
 		pixel.readUInt8(image.buffer.data, (4 * (y + image.offsetY) * image.buffer.width + (x + image.offsetX) * 4), image.buffer.format,
 			image.buffer.premultiplied);
@@ -863,9 +863,9 @@ class ImageDataUtil
 
 			var dataView = new ImageDataView(image, rect);
 			var position;
-			var argb:ARGB = new RGBA();
-			var bgra:BGRA = new BGRA();
-			var pixel:RGBA = new RGBA();
+			var argb:ARGB = 0;
+			var bgra:BGRA = 0;
+			var pixel:RGBA = 0;
 			var destPosition = 0;
 
 			for (y in 0...dataView.height)
@@ -922,8 +922,8 @@ class ImageDataUtil
 			var destPremultiplied = image.buffer.premultiplied;
 
 			var sourcePosition, destPosition;
-			var sourcePixel:RGBA = new RGBA();
-			var destPixel:RGBA = new RGBA();
+			var sourcePixel:RGBA = 0;
+			var destPixel:RGBA = 0;
 
 			for (y in 0...destView.height)
 			{
@@ -964,7 +964,7 @@ class ImageDataUtil
 		{
 			var format = image.buffer.format;
 			var length = Std.int(data.length / 4);
-			var pixel:RGBA = new RGBA();
+			var pixel:RGBA = 0;
 
 			for (i in 0...length)
 			{
@@ -1347,8 +1347,8 @@ class ImageDataUtil
 
 			var srcPosition,
 				destPosition,
-				srcPixel:RGBA  = new RGBA(),
-				destPixel:RGBA  = new RGBA(),
+				srcPixel:RGBA  = 0,
+				destPixel:RGBA  = 0,
 				pixelMask:UInt,
 				test:Bool,
 				value:Int;
@@ -1414,7 +1414,7 @@ class ImageDataUtil
 		{
 			var format = image.buffer.format;
 			var length = Std.int(data.length / 4);
-			var pixel:RGBA  = new RGBA();
+			var pixel:RGBA  = 0;
 
 			for (i in 0...length)
 			{

--- a/src/lime/graphics/CairoRenderContext.hx
+++ b/src/lime/graphics/CairoRenderContext.hx
@@ -16,6 +16,7 @@ import lime.graphics.cairo.Cairo;
 **/
 @:access(lime.graphics.RenderContext)
 @:forward
+@:transitive
 abstract CairoRenderContext(Cairo) from Cairo to Cairo
 {
 	@:from private static function fromRenderContext(context:RenderContext):CairoRenderContext

--- a/src/lime/graphics/Canvas2DRenderContext.hx
+++ b/src/lime/graphics/Canvas2DRenderContext.hx
@@ -26,6 +26,7 @@ abstract Canvas2DRenderContext(CanvasRenderingContext2D) from CanvasRenderingCon
 }
 #else
 @:forward()
+@:transitive
 abstract Canvas2DRenderContext(Dynamic) from Dynamic to Dynamic
 {
 	@:from private static function fromRenderContext(context:RenderContext):Canvas2DRenderContext

--- a/src/lime/graphics/DOMRenderContext.hx
+++ b/src/lime/graphics/DOMRenderContext.hx
@@ -26,6 +26,7 @@ abstract DOMRenderContext(Element) from Element to Element
 }
 #else
 @:forward
+@:transitive
 abstract DOMRenderContext(Dynamic) from Dynamic to Dynamic
 {
 	@:from private static function fromRenderContext(context:RenderContext):DOMRenderContext

--- a/src/lime/graphics/FlashRenderContext.hx
+++ b/src/lime/graphics/FlashRenderContext.hx
@@ -26,6 +26,7 @@ abstract FlashRenderContext(Sprite) from Sprite to Sprite
 }
 #else
 @:forward
+@:transitive
 abstract FlashRenderContext(Dynamic) from Dynamic to Dynamic
 {
 	@:from private static function fromRenderContext(context:RenderContext):FlashRenderContext

--- a/src/lime/graphics/OpenGLES2RenderContext.hx
+++ b/src/lime/graphics/OpenGLES2RenderContext.hx
@@ -78,6 +78,7 @@ import lime.graphics.opengl.*;
 	uniform1f, uniform1fv, uniform1i, uniform1iv, uniform2f, uniform2fv, uniform2i, uniform2iv, uniform3f, uniform3fv, uniform3i, uniform3iv, uniform4f,
 	uniform4fv, uniform4i, uniform4iv, uniformMatrix2fv, uniformMatrix3fv, uniformMatrix4fv, useProgram, validateProgram, vertexAttrib1f, vertexAttrib1fv,
 	vertexAttrib2f, vertexAttrib2fv, vertexAttrib3f, vertexAttrib3fv, vertexAttrib4f, vertexAttrib4fv, vertexAttribPointer, viewport, EXTENSIONS, type, version)
+@:transitive
 abstract OpenGLES2RenderContext(OpenGLES3RenderContext) from OpenGLES3RenderContext
 #if (!doc_gen && lime_opengl) from OpenGLRenderContext #end
 {
@@ -95,6 +96,7 @@ abstract OpenGLES2RenderContext(OpenGLES3RenderContext) from OpenGLES3RenderCont
 import lime.graphics.opengl.GL;
 
 @:forward()
+@:transitive
 abstract OpenGLES2RenderContext(Dynamic) from Dynamic to Dynamic
 {
 	@:from private static function fromGL(gl:Class<GL>):OpenGLES2RenderContext

--- a/src/lime/graphics/OpenGLES3RenderContext.hx
+++ b/src/lime/graphics/OpenGLES3RenderContext.hx
@@ -45,6 +45,7 @@ import lime.utils.Int32Array;
 abstract OpenGLES3RenderContext(NativeOpenGLRenderContext) from NativeOpenGLRenderContext
 {
 #else
+@:transitive
 abstract OpenGLES3RenderContext(OpenGLRenderContext) from OpenGLRenderContext
 {
 #end
@@ -4865,6 +4866,7 @@ public inline function waitSync(sync:GLSync, flags:Int, timeout:Int64):Void
 import lime.graphics.opengl.GL;
 
 @:forward()
+@:transitive
 abstract OpenGLES3RenderContext(Dynamic) from Dynamic to Dynamic
 {
 	@:from private static function fromRenderContext(context:RenderContext):OpenGLES3RenderContext

--- a/src/lime/graphics/OpenGLRenderContext.hx
+++ b/src/lime/graphics/OpenGLRenderContext.hx
@@ -42,6 +42,7 @@ abstract OpenGLRenderContext(NativeOpenGLRenderContext) from NativeOpenGLRenderC
 }
 #else
 @:forward()
+@:transitive
 abstract OpenGLRenderContext(Dynamic) from Dynamic to Dynamic
 {
 	@:from private static function fromRenderContext(context:RenderContext):OpenGLRenderContext

--- a/src/lime/graphics/WebGL2RenderContext.hx
+++ b/src/lime/graphics/WebGL2RenderContext.hx
@@ -300,6 +300,7 @@ import lime.utils.UInt32Array;
 **/
 @:access(lime.graphics.RenderContext)
 #if !doc_gen
+@:transitive
 abstract WebGL2RenderContext(OpenGLRenderContext) from OpenGLRenderContext to OpenGLRenderContext
 {
 #else

--- a/src/lime/graphics/WebGLRenderContext.hx
+++ b/src/lime/graphics/WebGLRenderContext.hx
@@ -73,6 +73,7 @@ import lime.utils.Float32Array;
 	uniform2i, uniform2iv, uniform3f, uniform3fv, uniform3i, uniform3iv, uniform4f, uniform4fv, uniform4i, uniform4iv, useProgram, validateProgram,
 	vertexAttrib1f, vertexAttrib1fv, vertexAttrib2f, vertexAttrib2fv, vertexAttrib3f, vertexAttrib3fv, vertexAttrib4f, vertexAttrib4fv, vertexAttribPointer,
 	viewport)
+@:transitive
 abstract WebGLRenderContext(WebGL2RenderContext)
 {
 	public function bufferData(target:Int, srcData:#if (!js || !html5 || display) ArrayBufferView #else Dynamic #end, usage:Int):Void

--- a/src/lime/media/openal/ALBuffer.hx
+++ b/src/lime/media/openal/ALBuffer.hx
@@ -4,6 +4,7 @@ package lime.media.openal;
 import lime.system.CFFIPointer;
 
 @:allow(lime.media.openal.AL)
+@:transitive
 abstract ALBuffer(CFFIPointer) from CFFIPointer to CFFIPointer
 {
 	@:noCompletion private inline function new(handle:CFFIPointer)

--- a/src/lime/text/harfbuzz/HBBuffer.hx
+++ b/src/lime/text/harfbuzz/HBBuffer.hx
@@ -106,6 +106,58 @@ abstract HBBuffer(CFFIPointer) from CFFIPointer to CFFIPointer
 		return null;
 		#end
 	}
+	public function getGlyphInfoArrays()
+	{
+		#if (lime_cffi && lime_harfbuzz && !macro)
+		var bytes = Bytes.alloc(0);
+		bytes = NativeCFFI.lime_hb_buffer_get_glyph_infos(this, bytes);
+
+		if (bytes == null)
+		{
+			return null;
+		}
+		else
+		{
+
+			var length = bytes.length;
+			var position = 0, info;
+
+			var size:Int = Math.floor(length / (4*3));
+
+			var codepoint:Array<Int> = new Array();
+			var mask:Array<Int> = new Array();
+			var cluster:Array<Int> = new Array();
+
+			codepoint.resize(size);
+			mask.resize(size);
+			cluster.resize(size);
+
+			var i:Int = 0;
+			while (position < length)
+			{
+				codepoint[i] = bytes.getInt32(position);
+				position += 4;
+
+				mask[i] = bytes.getInt32(position);
+				position += 4;
+
+				cluster[i] = bytes.getInt32(position);
+				position += 4;
+
+				++i;
+
+			}
+
+			return {
+				codepoint:codepoint,
+				mask:mask,
+				cluster:cluster
+			};
+		}
+		#else
+		return null;
+		#end
+	}
 
 	public function getGlyphPositions():Array<HBGlyphPosition>
 	{
@@ -122,7 +174,8 @@ abstract HBBuffer(CFFIPointer) from CFFIPointer to CFFIPointer
 			var result = new Array<HBGlyphPosition>();
 
 			var length = bytes.length;
-			var position = 0, glyphPosition;
+			var position:Int = 0;
+			var glyphPosition;
 
 			while (position < length)
 			{
@@ -139,6 +192,63 @@ abstract HBBuffer(CFFIPointer) from CFFIPointer to CFFIPointer
 			}
 
 			return result;
+		}
+		#else
+		return null;
+		#end
+	}
+	public function getGlyphPositionsArrays()
+	{
+		#if (lime_cffi && lime_harfbuzz && !macro)
+		var bytes = Bytes.alloc(0);
+		bytes = NativeCFFI.lime_hb_buffer_get_glyph_positions(this, bytes);
+
+		if (bytes == null)
+		{
+			return null;
+		}
+		else
+		{
+			var result = new Array<HBGlyphPosition>();
+
+			var length = bytes.length;
+			var position = 0, glyphPosition;
+
+			var size:Int = Math.floor(length / (4*4));
+
+			var xAdvance:Array<Int> = new Array();
+			var xOffset:Array<Int> = new Array();
+			var yAdvance:Array<Int> = new Array();
+			var yOffset:Array<Int> = new Array();
+
+			xAdvance.resize(size);
+			xOffset.resize(size);
+			yAdvance.resize(size);
+			yOffset.resize(size);
+
+			var i:Int = 0;
+			while (position < length)
+			{
+				xAdvance[i] = bytes.getInt32(position);
+				position += 4;
+
+				yAdvance[i]= bytes.getInt32(position);
+				position += 4;
+
+				xOffset[i] = bytes.getInt32(position);
+				position += 4;
+
+				yOffset[i] = bytes.getInt32(position);
+				position += 4;
+				++i;
+			}
+
+			return {
+				xAdvance:xAdvance,
+				xOffset:xOffset,
+				yAdvance:yAdvance,
+				yOffset:yOffset
+			};
 		}
 		#else
 		return null;

--- a/src/lime/text/harfbuzz/HBBuffer.hx
+++ b/src/lime/text/harfbuzz/HBBuffer.hx
@@ -106,58 +106,6 @@ abstract HBBuffer(CFFIPointer) from CFFIPointer to CFFIPointer
 		return null;
 		#end
 	}
-	public function getGlyphInfoArrays()
-	{
-		#if (lime_cffi && lime_harfbuzz && !macro)
-		var bytes = Bytes.alloc(0);
-		bytes = NativeCFFI.lime_hb_buffer_get_glyph_infos(this, bytes);
-
-		if (bytes == null)
-		{
-			return null;
-		}
-		else
-		{
-
-			var length = bytes.length;
-			var position = 0, info;
-
-			var size:Int = Math.floor(length / (4*3));
-
-			var codepoint:Array<Int> = new Array();
-			var mask:Array<Int> = new Array();
-			var cluster:Array<Int> = new Array();
-
-			codepoint.resize(size);
-			mask.resize(size);
-			cluster.resize(size);
-
-			var i:Int = 0;
-			while (position < length)
-			{
-				codepoint[i] = bytes.getInt32(position);
-				position += 4;
-
-				mask[i] = bytes.getInt32(position);
-				position += 4;
-
-				cluster[i] = bytes.getInt32(position);
-				position += 4;
-
-				++i;
-
-			}
-
-			return {
-				codepoint:codepoint,
-				mask:mask,
-				cluster:cluster
-			};
-		}
-		#else
-		return null;
-		#end
-	}
 
 	public function getGlyphPositions():Array<HBGlyphPosition>
 	{
@@ -174,8 +122,7 @@ abstract HBBuffer(CFFIPointer) from CFFIPointer to CFFIPointer
 			var result = new Array<HBGlyphPosition>();
 
 			var length = bytes.length;
-			var position:Int = 0;
-			var glyphPosition;
+			var position = 0, glyphPosition;
 
 			while (position < length)
 			{
@@ -192,63 +139,6 @@ abstract HBBuffer(CFFIPointer) from CFFIPointer to CFFIPointer
 			}
 
 			return result;
-		}
-		#else
-		return null;
-		#end
-	}
-	public function getGlyphPositionsArrays()
-	{
-		#if (lime_cffi && lime_harfbuzz && !macro)
-		var bytes = Bytes.alloc(0);
-		bytes = NativeCFFI.lime_hb_buffer_get_glyph_positions(this, bytes);
-
-		if (bytes == null)
-		{
-			return null;
-		}
-		else
-		{
-			var result = new Array<HBGlyphPosition>();
-
-			var length = bytes.length;
-			var position = 0, glyphPosition;
-
-			var size:Int = Math.floor(length / (4*4));
-
-			var xAdvance:Array<Int> = new Array();
-			var xOffset:Array<Int> = new Array();
-			var yAdvance:Array<Int> = new Array();
-			var yOffset:Array<Int> = new Array();
-
-			xAdvance.resize(size);
-			xOffset.resize(size);
-			yAdvance.resize(size);
-			yOffset.resize(size);
-
-			var i:Int = 0;
-			while (position < length)
-			{
-				xAdvance[i] = bytes.getInt32(position);
-				position += 4;
-
-				yAdvance[i]= bytes.getInt32(position);
-				position += 4;
-
-				xOffset[i] = bytes.getInt32(position);
-				position += 4;
-
-				yOffset[i] = bytes.getInt32(position);
-				position += 4;
-				++i;
-			}
-
-			return {
-				xAdvance:xAdvance,
-				xOffset:xOffset,
-				yAdvance:yAdvance,
-				yOffset:yOffset
-			};
 		}
 		#else
 		return null;

--- a/src/lime/utils/BytePointer.hx
+++ b/src/lime/utils/BytePointer.hx
@@ -7,6 +7,7 @@ import lime.utils.Bytes as LimeBytes;
 @:access(haxe.io.Bytes)
 @:access(lime.utils.BytePointerData)
 @:forward()
+@:transitive
 abstract BytePointer(BytePointerData) from BytePointerData to BytePointerData
 {
 	public inline function new(bytes:Bytes = null, offset:Int = 0):Void

--- a/src/lime/utils/Bytes.hx
+++ b/src/lime/utils/Bytes.hx
@@ -13,6 +13,7 @@ import lime.net.HTTPRequest;
 @:access(haxe.io.Bytes)
 @:access(lime._internal.backend.native.NativeCFFI)
 @:forward()
+@:transitive
 abstract Bytes(HaxeBytes) from HaxeBytes to HaxeBytes
 {
 	public function new(length:Int, bytesData:BytesData)

--- a/src/lime/utils/DataPointer.hx
+++ b/src/lime/utils/DataPointer.hx
@@ -15,6 +15,7 @@ import lime._internal.backend.native.NativeCFFI;
 @:access(lime._internal.backend.native.NativeCFFI)
 #end
 @:access(haxe.io.Bytes)
+@:transitive
 abstract DataPointer(DataPointerType) to DataPointerType
 {
 	@:noCompletion private function new(data:#if !doc_gen DataPointerType #else Dynamic #end)

--- a/src/lime/utils/Float32Array.hx
+++ b/src/lime/utils/Float32Array.hx
@@ -96,6 +96,7 @@ abstract Float32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
+	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Float>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Float32Array.hx
+++ b/src/lime/utils/Float32Array.hx
@@ -96,7 +96,6 @@ abstract Float32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
-	@:generic
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Float>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Float32Array.hx
+++ b/src/lime/utils/Float32Array.hx
@@ -10,6 +10,7 @@ import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
 @:arrayAccess
+@:transitive
 abstract Float32Array(JSFloat32Array) from JSFloat32Array to JSFloat32Array
 {
 	@:to function toArrayBufferView ():ArrayBufferView return this;
@@ -86,6 +87,7 @@ abstract Float32Array(JSFloat32Array) from JSFloat32Array to JSFloat32Array
 import lime.utils.ArrayBuffer;
 import lime.utils.ArrayBufferView;
 
+@:transitive
 @:forward
 abstract Float32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 {

--- a/src/lime/utils/Float64Array.hx
+++ b/src/lime/utils/Float64Array.hx
@@ -93,6 +93,7 @@ abstract Float64Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
+	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Float>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Float64Array.hx
+++ b/src/lime/utils/Float64Array.hx
@@ -9,6 +9,7 @@ import js.html.Float64Array as JSFloat64Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
+@:transitive
 abstract Float64Array(JSFloat64Array) from JSFloat64Array to JSFloat64Array
 {
 	@:to inline function toArrayBufferView ():ArrayBufferView return this;
@@ -84,6 +85,7 @@ abstract Float64Array(JSFloat64Array) from JSFloat64Array to JSFloat64Array
 #else
 import lime.utils.ArrayBufferView;
 
+@:transitive
 @:forward
 abstract Float64Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 {

--- a/src/lime/utils/Float64Array.hx
+++ b/src/lime/utils/Float64Array.hx
@@ -93,7 +93,6 @@ abstract Float64Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
-	@:generic
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Float>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Int16Array.hx
+++ b/src/lime/utils/Int16Array.hx
@@ -92,7 +92,7 @@ abstract Int16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 	public inline static var BYTES_PER_ELEMENT:Int = 2;
 
 	public var length(get, never):Int;
-
+	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Int16Array.hx
+++ b/src/lime/utils/Int16Array.hx
@@ -93,7 +93,6 @@ abstract Int16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
-	@:generic
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Int16Array.hx
+++ b/src/lime/utils/Int16Array.hx
@@ -92,6 +92,7 @@ abstract Int16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 	public inline static var BYTES_PER_ELEMENT:Int = 2;
 
 	public var length(get, never):Int;
+	
 	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)

--- a/src/lime/utils/Int16Array.hx
+++ b/src/lime/utils/Int16Array.hx
@@ -92,7 +92,7 @@ abstract Int16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 	public inline static var BYTES_PER_ELEMENT:Int = 2;
 
 	public var length(get, never):Int;
-	
+
 	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)

--- a/src/lime/utils/Int16Array.hx
+++ b/src/lime/utils/Int16Array.hx
@@ -9,6 +9,7 @@ import js.html.Int16Array as JSInt16Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
+@:transitive
 abstract Int16Array(JSInt16Array) from JSInt16Array to JSInt16Array
 {
 	@:to inline function toArrayBufferView ():ArrayBufferView return this;
@@ -84,6 +85,7 @@ abstract Int16Array(JSInt16Array) from JSInt16Array to JSInt16Array
 #else
 import lime.utils.ArrayBufferView;
 
+@:transitive
 @:forward
 abstract Int16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 {

--- a/src/lime/utils/Int32Array.hx
+++ b/src/lime/utils/Int32Array.hx
@@ -92,6 +92,7 @@ abstract Int32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
+	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Int32Array.hx
+++ b/src/lime/utils/Int32Array.hx
@@ -92,7 +92,6 @@ abstract Int32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
-	@:generic
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Int32Array.hx
+++ b/src/lime/utils/Int32Array.hx
@@ -9,6 +9,7 @@ import js.html.Int32Array as JSInt32Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
+@:transitive
 abstract Int32Array(JSInt32Array) from JSInt32Array to JSInt32Array
 {
 	@:to inline function toArrayBufferView ():ArrayBufferView return this;
@@ -83,7 +84,7 @@ abstract Int32Array(JSInt32Array) from JSInt32Array to JSInt32Array
 }
 #else
 import lime.utils.ArrayBufferView;
-
+@:transitive
 @:forward
 abstract Int32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 {

--- a/src/lime/utils/Int8Array.hx
+++ b/src/lime/utils/Int8Array.hx
@@ -91,7 +91,6 @@ abstract Int8Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
-	@:generic
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Int8Array.hx
+++ b/src/lime/utils/Int8Array.hx
@@ -91,6 +91,7 @@ abstract Int8Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
+	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/Int8Array.hx
+++ b/src/lime/utils/Int8Array.hx
@@ -9,6 +9,7 @@ import js.html.Int8Array as JSInt8Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
+@:transitive
 abstract Int8Array(JSInt8Array) from JSInt8Array to JSInt8Array
 {
 	@:to inline function toArrayBufferView ():ArrayBufferView return this;
@@ -82,6 +83,7 @@ abstract Int8Array(JSInt8Array) from JSInt8Array to JSInt8Array
 #else
 import lime.utils.ArrayBufferView;
 
+@:transitive
 @:forward
 abstract Int8Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 {

--- a/src/lime/utils/Resource.hx
+++ b/src/lime/utils/Resource.hx
@@ -2,6 +2,7 @@ package lime.utils;
 
 import haxe.io.Bytes;
 
+@:transitive
 abstract Resource(Bytes) from Bytes to Bytes
 {
 	public function new(size:Int = 0)

--- a/src/lime/utils/UInt16Array.hx
+++ b/src/lime/utils/UInt16Array.hx
@@ -92,7 +92,6 @@ abstract UInt16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
-	@:generic
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/UInt16Array.hx
+++ b/src/lime/utils/UInt16Array.hx
@@ -92,6 +92,7 @@ abstract UInt16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
+	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/UInt16Array.hx
+++ b/src/lime/utils/UInt16Array.hx
@@ -9,6 +9,7 @@ import js.html.Uint8Array as JSUInt8Array;
 import js.html.Uint16Array as JSUInt16Array;
 #end
 @:forward
+@:transitive
 abstract UInt16Array(JSUInt16Array) from JSUInt16Array to JSUInt16Array
 {
 	@:to inline function toArrayBufferView ():ArrayBufferView return this;
@@ -83,7 +84,7 @@ abstract UInt16Array(JSUInt16Array) from JSUInt16Array to JSUInt16Array
 }
 #else
 import lime.utils.ArrayBufferView;
-
+@:transitive
 @:forward
 abstract UInt16Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 {

--- a/src/lime/utils/UInt32Array.hx
+++ b/src/lime/utils/UInt32Array.hx
@@ -9,6 +9,7 @@ import js.html.Uint8Array as JSUInt8Array;
 import js.html.Uint32Array as JSUInt32Array;
 #end
 @:forward
+@:transitive
 abstract UInt32Array(JSUInt32Array) from JSUInt32Array to JSUInt32Array
 {
 	@:to inline function toArrayBufferView ():ArrayBufferView return this;
@@ -83,7 +84,7 @@ abstract UInt32Array(JSUInt32Array) from JSUInt32Array to JSUInt32Array
 }
 #else
 import lime.utils.ArrayBufferView;
-
+@:transitive
 @:forward
 abstract UInt32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 {

--- a/src/lime/utils/UInt32Array.hx
+++ b/src/lime/utils/UInt32Array.hx
@@ -92,6 +92,7 @@ abstract UInt32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
+	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/UInt32Array.hx
+++ b/src/lime/utils/UInt32Array.hx
@@ -92,7 +92,6 @@ abstract UInt32Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
-	@:generic
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/UInt8Array.hx
+++ b/src/lime/utils/UInt8Array.hx
@@ -90,6 +90,7 @@ abstract UInt8Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
+	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/UInt8Array.hx
+++ b/src/lime/utils/UInt8Array.hx
@@ -90,7 +90,6 @@ abstract UInt8Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 
 	public var length(get, never):Int;
 
-	@:generic
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/UInt8Array.hx
+++ b/src/lime/utils/UInt8Array.hx
@@ -7,6 +7,7 @@ import js.lib.Uint8Array as JSUInt8Array;
 import js.html.Uint8Array as JSUInt8Array;
 #end
 @:forward
+@:transitive
 abstract UInt8Array(JSUInt8Array) from JSUInt8Array to JSUInt8Array
 {
 	@:to inline function toArrayBufferView ():ArrayBufferView return this;
@@ -81,7 +82,7 @@ abstract UInt8Array(JSUInt8Array) from JSUInt8Array to JSUInt8Array
 }
 #else
 import lime.utils.ArrayBufferView;
-
+@:transitive
 @:forward
 abstract UInt8Array(ArrayBufferView) from ArrayBufferView to ArrayBufferView
 {

--- a/src/lime/utils/UInt8ClampedArray.hx
+++ b/src/lime/utils/UInt8ClampedArray.hx
@@ -102,7 +102,6 @@ abstract UInt8ClampedArray(ArrayBufferView) from ArrayBufferView to ArrayBufferV
 
 	public var length(get, never):Int;
 
-	@:generic
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/UInt8ClampedArray.hx
+++ b/src/lime/utils/UInt8ClampedArray.hx
@@ -102,6 +102,7 @@ abstract UInt8ClampedArray(ArrayBufferView) from ArrayBufferView to ArrayBufferV
 
 	public var length(get, never):Int;
 
+	#if (haxe_ver < 4.2) @:generic #end
 	public inline function new<T>(?elements:Int, ?buffer:ArrayBuffer, ?array:Array<T>, #if openfl ?vector:openfl.Vector<Int>, #end ?view:ArrayBufferView,
 			?byteoffset:Int = 0, ?len:Null<Int>)
 	{

--- a/src/lime/utils/UInt8ClampedArray.hx
+++ b/src/lime/utils/UInt8ClampedArray.hx
@@ -9,6 +9,7 @@ import js.html.Uint8Array as JSUInt8Array;
 import js.html.Uint8ClampedArray as JSUInt8ClampedArray;
 #end
 @:forward
+@:transitive
 abstract UInt8ClampedArray(JSUInt8ClampedArray) from JSUInt8ClampedArray to JSUInt8ClampedArray
 {
 	@:to inline function toArrayBufferView ():ArrayBufferView return this;
@@ -92,7 +93,7 @@ abstract UInt8ClampedArray(JSUInt8ClampedArray) from JSUInt8ClampedArray to JSUI
 }
 #else
 import lime.utils.ArrayBufferView;
-
+@:transitive
 @:forward
 @:arrayAccess
 abstract UInt8ClampedArray(ArrayBufferView) from ArrayBufferView to ArrayBufferView


### PR DESCRIPTION
Here's an attempt to make Lime build with Haxe 4.2
It looks like the behavior for Abstracts has been changed a bit. 
- `@:transitive` is necessary for "chained" implicit casts  
- it looks like  `@:generic`  is not allowed on abstracts constructors.
- Not sure if it affects all kinds of abstracts or just some cases, but the compiler won’t  accept  uninitialized  variables of some abstract types.

i also upgraded the hxcpp version in the workflow.