### PR TITLE
fix: Shader compiler is giving warnings only when there are errors present

### DIFF
--- a/src/lime/graphics/opengl/GLShader.hx
+++ b/src/lime/graphics/opengl/GLShader.hx
@@ -26,18 +26,27 @@ public static function fromSource(gl:WebGLRenderContext, source:String, type:Int
 	var shader = gl.createShader(type);
 	gl.shaderSource(shader, source);
 	gl.compileShader(shader);
+	var shaderInfoLog = gl.getShaderInfoLog(shader);
+	var compileStatus = gl.getShaderParameter(shader, gl.COMPILE_STATUS);
 
-	if (gl.getShaderParameter(shader, gl.COMPILE_STATUS) == 0)
+	if (shaderInfoLog != null || compileStatus == 0)
 	{
 		var message;
 
-		if (type == gl.VERTEX_SHADER) message = "Error compiling vertex shader";
-		else if (type == gl.FRAGMENT_SHADER) message = "Error compiling fragment shader";
-		else
-			message = "Error compiling unknown shader type";
+		if (compileStatus == 0)	message = "Error ";
+		else message = "Info ";
 
-		message += "\n" + gl.getShaderInfoLog(shader);
-		Log.error(message);
+		if (type == gl.VERTEX_SHADER) message = "compiling vertex shader";
+		else if (type == gl.FRAGMENT_SHADER) message = "compiling fragment shader";
+		else
+			message = "compiling unknown shader type";
+
+		message += "\n" + shaderInfoLog;
+
+		if(compileStatus == 0)
+			Log.error(message);
+		else if(shaderInfoLog != null)
+			Log.debug(message);
 	}
 
 	return shader;


### PR DESCRIPTION
Fixes #1451.
The new code uses both `getShaderInfoLog()` and `getShaderParameter()` to recognize the following states:

- no errors, no warnings: (`shaderInfoLog = null`, `compileStatus = 1`) --> show nothing;
- no errors,  warnings present: (`shaderInfoLog != null`, `compileStatus = 1`) --> show "Info compiling shader..." & infoLog on Log.debug();
- errors present: (`shaderInfoLog != null`, `compileStatus = 0`) --> show "Error compliling shader..." & infoLog on Log.error().