### PR TITLE
Making NativeAudio buffers configurable &  playback  behaving like other sources.

### DIFF
--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -19,10 +19,10 @@ import lime.utils.UInt8Array;
 class NativeAudioSource
 {
 	private static var STREAM_BUFFER_SIZE = 48000;
-	#if !(!native_audio_buffers || macro)
-	private static var STREAM_NUM_BUFFERS = 3;
+	#if (native_audio_buffers && !macro)
+	private static var STREAM_NUM_BUFFERS = Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers"));
 	#else
-	private static var STREAM_NUM_BUFFERS =  Std.parseInt(haxe.macro.Compiler.getDefine("native_audio_buffers"));
+	private static var STREAM_NUM_BUFFERS = 3;
 	#end
 	private static var STREAM_TIMER_FREQUENCY = 100;
 

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -294,9 +294,10 @@ class NativeAudioSource
 
 			AL.sourceQueueBuffers(handle, numBuffers, buffers);
 
-			// If openAL runs out of buffer it will stop playback.
-			// This check is here to recover from this and resume playback
-			// this situation typically happens when resizing window or other operations that freezes the main thread
+			// OpenAL can unexpectedly stop playback if the buffers fill up,
+			// which typically happens if an operation (such as resizing a
+			// window) freezes the main thread.
+			// If AL is supposed to be playing but isn't, restart it here.
 			if (playing && handle != null && AL.getSourcei(handle, AL.SOURCE_STATE) == AL.STOPPED){
 				AL.sourcePlay(handle);
 			}


### PR DESCRIPTION
In order to make  music streaming usable in OpenFL on native targets some tweaks to Lime is necessary.

1. when using stop, expected behavior in OpenFL is to return to the beginning of a track ( the current behavior is more like a pause )  so i have changed this  (see line 312)

2. when the backend runs out of buffer it stops playing (and seems to refuse to continue), this becomes an issue when the main thread is occupied for too long (loading assets, resizing window etc.) so i have added check to see if it was playing before it ran out of buffer and if so, resume playback. (line 296 - 302)

3. Since the buffers are quite small and only 3 by default  any small holdup in the main thread might cause stuttering, i have therefor added an option to set a different amount of buffers when compiling  by setting `native_audio_buffers`to  the desired amount.