### PR TITLE
fix: getShaderInfoLog result could be null on HashLink target

### DIFF
--- a/src/lime/_internal/backend/native/NativeOpenGLRenderContext.hx
+++ b/src/lime/_internal/backend/native/NativeOpenGLRenderContext.hx
@@ -2040,7 +2040,7 @@ class NativeOpenGLRenderContext
 		#if (lime_cffi && (lime_opengl || lime_opengles) && !macro)
 		var result = NativeCFFI.lime_gl_get_shader_info_log(__getObjectID(shader));
 		#if hl
-		var result = @:privateAccess String.fromUTF8(result);
+		var result = (result != null) ? @:privateAccess String.fromUTF8(result) : null;
 		#end
 		return result;
 		#else


### PR DESCRIPTION
The `lime_gl_get_shader_info_log` function could, sometimes, return null. Also, it seems not yet implemented for the HashLink target, so at the moment it would always return null. 

However, in the hl target we are also forcing a conversion to String that is causing the function to crash when the result is null (see [this issue in OpenFL](https://github.com/openfl/openfl/pull/2473#issuecomment-820727777)).

This PR adds a check if the result is null before attempting the conversion.