### PR TITLE
Fix playback behavior in `NativeAudioSource`

### DIFF
--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -310,7 +310,6 @@ class NativeAudioSource
 		if (playing && handle != null && AL.getSourcei(handle, AL.SOURCE_STATE) == AL.PLAYING)
 		{
 			AL.sourceStop(handle);
-			setCurrentTime(0);
 		}
 
 		playing = false;
@@ -324,6 +323,8 @@ class NativeAudioSource
 		{
 			timer.stop();
 		}
+		
+		setCurrentTime(0);
 	}
 
 	// Event Handlers

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -294,9 +294,9 @@ class NativeAudioSource
 
 			AL.sourceQueueBuffers(handle, numBuffers, buffers);
 
-			// OpenAL can unexpectedly stop playback if the buffers fill up,
-			// which typically happens if an operation (such as resizing a
-			// window) freezes the main thread.
+			// OpenAL can unexpectedly stop playback if the buffers run out
+			// of data, which typically happens if an operation (such as
+			// resizing a window) freezes the main thread.
 			// If AL is supposed to be playing but isn't, restart it here.
 			if (playing && handle != null && AL.getSourcei(handle, AL.SOURCE_STATE) == AL.STOPPED){
 				AL.sourcePlay(handle);


### PR DESCRIPTION
The sequel to pull #1456, this request fixes two issues brought up in that thread. I would love to have amended that request, but I didn't feel like spending the time to figure out how.

Anyway, the big issue is that sound could potentially play despite `playing` being false. Besides that, one of the comments was incorrect.