### PR TITLE
Don't let packed asset files begin with a compression header

### DIFF
--- a/src/lime/tools/AssetHelper.hx
+++ b/src/lime/tools/AssetHelper.hx
@@ -295,6 +295,13 @@ class AssetHelper
 		if (asset.type == TEMPLATE) return null;
 		if (asset.library == library.name || (asset.library == null && library.name == DEFAULT_LIBRARY_NAME))
 		{
+			if (output.tell() == 0)
+			{
+				//write some dummy text at the start of the packed asset file just to prevent
+				//the file from beginning with a packed file header.
+				output.writeString("asset-pack");
+			}
+
 			var assetData:Dynamic =
 				{
 					id: asset.id,

--- a/src/lime/tools/AssetHelper.hx
+++ b/src/lime/tools/AssetHelper.hx
@@ -299,7 +299,7 @@ class AssetHelper
 			{
 				//write some dummy text at the start of the packed asset file just to prevent
 				//the file from beginning with a packed file header.
-				output.writeString("asset-pack");
+				output.writeString("lime-asset-pack");
 			}
 
 			var assetData:Dynamic =


### PR DESCRIPTION
Packed asset libraries are sequences of individual files, sometimes compressed, and concatenated. If each file is compressed, this causes the asset pack as a whole to begin with compressed file headers, which may cause some software to mistake the file as being one large compressed file, which it isn't.

For example, some html5 web portals (in particular, the very popular itch.io) may try to automatically determine if a file is gzip-compressed, and if they are, serve the file with the "content-encoding: gzip" header. That will cause a web browser to decompress the file while downloading it, leading to two issues:

1. The compressed file header is only for the first file in the pack, so we'll only receive the data for the first file.
2. The data will be in an already-decompressed state, which we don't expect.

To illustrate, the file looks like this:
```
[                               default.pak                                           ]
[packed-asset-1.gzip][packed-asset-2.gzip][packed-asset-3.gzip]...[packed-asset-N.gzip]
```

What we receive from the download is this:
```
[asset-1-already-unzipped] ... nothing else
```

This will manifest as an error like "Uncaught incorrect header check" when trying to load and decompress what we expect to be compressed data.

This change prepends the string "asset-pack" to the start of the file. It's applied to all pack types, not just compressed ones. For uncompressed packs, I presume that there's the possibility that whatever file header happens to be present on the first file in the pack has other inadvertent effects.