### PR TITLE
Remove lime-samples dependency in `createProject`.

### DIFF
--- a/tools/utils/CreateTemplate.hx
+++ b/tools/utils/CreateTemplate.hx
@@ -123,7 +123,6 @@ class CreateTemplate
 		if (projectName != null && projectName != "")
 		{
 			var defines = new Map<String, Dynamic>();
-			defines.set("create", 1);
 			var project = HXProject.fromHaxelib(new Haxelib(projectName), defines);
 
 			if (project != null)


### PR DESCRIPTION
As pointed out in issue #976, `lime create project XYZ` doesn't rely on any project but Lime itself, and shouldn't try to [load lime-samples](https://github.com/haxelime/lime/blob/develop/include.xml#L203). As far as I can tell, setting "create" has no other effect.