### PR TITLE
Ignore project/obj in extensions.

### DIFF
--- a/templates/extension/.gitignore
+++ b/templates/extension/.gitignore
@@ -1,0 +1,9 @@
+project/obj/
+.DS_Store
+
+# Examples of other files you might choose to ignore
+#*.zip
+#ndll/*/*.a
+#ndll/*/*.so
+#ndll/*/*.ndll
+#ndll/*/*.hash


### PR DESCRIPTION
No one ever wants to include the intermediate build files. Might as well save them the trouble of making their own .gitignore file.

That said, I've found more than one project that includes the ndlls, so I left those as suggestions.