### PR TITLE
Fix error when loading embedded audio.

### DIFF
--- a/src/lime/utils/AssetLibrary.hx
+++ b/src/lime/utils/AssetLibrary.hx
@@ -464,7 +464,7 @@ class AssetLibrary
 		}
 		else if (classTypes.exists(id))
 		{
-			return Future.withValue(Type.createInstance(classTypes.get(id), []));
+			return Future.withValue(AudioBuffer.fromBytes(cast(Type.createInstance(classTypes.get(id), []), Bytes)));
 		}
 		else
 		{


### PR DESCRIPTION
Fixes #1477.

`loadAudioBuffer` skipped actually creating an `AudioBuffer`. Oops! Fortunately, `getAudioBuffer` handled this case correctly, so I copied that code.

(It struck me as odd that a `load` function would return synchronously, but the other `load` functions do the same, so I guess it's intended.)