### PR TITLE
Make a Consistent length when you're changing the pitch

### DIFF
--- a/src/lime/_internal/backend/flash/FlashAudioSource.hx
+++ b/src/lime/_internal/backend/flash/FlashAudioSource.hx
@@ -116,6 +116,15 @@ class FlashAudioSource
 	{
 		return loops = value;
 	}
+	public function getPitch():Float
+	{
+		return 1;
+	}
+
+	public function setPitch(value:Float):Float
+	{
+		return getPitch;
+	}
 
 	public function getPosition():Vector4
 	{

--- a/src/lime/_internal/backend/flash/FlashAudioSource.hx
+++ b/src/lime/_internal/backend/flash/FlashAudioSource.hx
@@ -123,7 +123,7 @@ class FlashAudioSource
 
 	public function setPitch(value:Float):Float
 	{
-		return getPitch;
+		return getPitch();
 	}
 
 	public function getPosition():Vector4

--- a/src/lime/_internal/backend/native/NativeAudioSource.hx
+++ b/src/lime/_internal/backend/native/NativeAudioSource.hx
@@ -40,6 +40,7 @@ class NativeAudioSource
 	private var stream:Bool;
 	private var streamTimer:Timer;
 	private var timer:Timer;
+	@:noCompletion private var initialPitch:Float;
 
 	public function new(parent:AudioSource)
 	{
@@ -515,6 +516,19 @@ class NativeAudioSource
 			position.y = value[1];
 			position.z = value[2];
 			#end
+		}
+
+		if (playing && getPitch() != initialPitch)
+		{
+			var timeRemaining = Std.int((getLength() - getCurrentTime()) / getPitch());
+			timer.stop();
+
+			if (timeRemaining > 0)
+			{
+				timer = new Timer(timeRemaining);
+				timer.run = timer_onRun;
+			}
+			initialPitch = getPitch();
 		}
 
 		return position;


### PR DESCRIPTION
So I made some rough code with the Native Audio Backend and made the looping go smooth whatever is the pitch on. This was tested on Hashlink so I guess that it should work on different platforms... Right?

(This Closes Issue Number #1511 And this comes with the Pull Request Number #1510 with the Review notes included)