### PR TITLE
Upgrade to android API level 21.

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -1,8 +1,6 @@
 <xml>
 
-	<set name="PLATFORM" value="android-16" if="android" unless="HXCPP_ARM64 || HXCPP_X86_64" />
-	<set name="PLATFORM" value="android-21" if="android HXCPP_ARM64" />
-	<set name="PLATFORM" value="android-21" if="android HXCPP_X86_64" />
+	<set name="PLATFORM" value="android-21" if="android" />
 	<set name="HXCPP_CPP11" value="1" />
 
 	<include name="${HXCPP}/build-tool/BuildCommon.xml" />

--- a/tools/platforms/AndroidPlatform.hx
+++ b/tools/platforms/AndroidPlatform.hx
@@ -71,8 +71,8 @@ class AndroidPlatform extends PlatformTarget
 
 		for (architecture in architectures)
 		{
-			var haxeParams = [hxml, "-D", "android", "-D", "PLATFORM=android-16"];
-			var cppParams = ["-Dandroid", "-DPLATFORM=android-16"];
+			var haxeParams = [hxml, "-D", "android", "-D", "PLATFORM=android-21"];
+			var cppParams = ["-Dandroid", "-DPLATFORM=android-21"];
 			var path = sourceSet + "/jniLibs/armeabi";
 			var suffix = ".so";
 
@@ -86,9 +86,6 @@ class AndroidPlatform extends PlatformTarget
 			}
 			else if (architecture == Architecture.ARM64)
 			{
-				haxeParams = [hxml, "-D", "android", "-D", "PLATFORM=android-21"];
-				cppParams = ["-Dandroid", "-DPLATFORM=android-21"];
-
 				haxeParams.push("-D");
 				haxeParams.push("HXCPP_ARM64");
 				cppParams.push("-DHXCPP_ARM64");
@@ -105,9 +102,6 @@ class AndroidPlatform extends PlatformTarget
 			}
 			else if (architecture == Architecture.X64)
 			{
-				haxeParams = [hxml, "-D", "android", "-D", "PLATFORM=android-21"];
-				cppParams = ["-Dandroid", "-DPLATFORM=android-21"];
-
 				haxeParams.push("-D");
 				haxeParams.push("HXCPP_X86_64");
 				cppParams.push("-DHXCPP_X86_64");
@@ -284,10 +278,10 @@ class AndroidPlatform extends PlatformTarget
 
 		var commands = [];
 
-		if (armv5) commands.push(["-Dandroid", "-DPLATFORM=android-16"]);
-		if (armv7) commands.push(["-Dandroid", "-DHXCPP_ARMV7", "-DHXCPP_ARM7", "-DPLATFORM=android-16"]);
+		if (armv5) commands.push(["-Dandroid", "-DPLATFORM=android-21"]);
+		if (armv7) commands.push(["-Dandroid", "-DHXCPP_ARMV7", "-DHXCPP_ARM7", "-DPLATFORM=android-21"]);
 		if (arm64) commands.push(["-Dandroid", "-DHXCPP_ARM64", "-DPLATFORM=android-21"]);
-		if (x86) commands.push(["-Dandroid", "-DHXCPP_X86", "-DPLATFORM=android-16"]);
+		if (x86) commands.push(["-Dandroid", "-DHXCPP_X86", "-DPLATFORM=android-21"]);
 		if (x64) commands.push(["-Dandroid", "-DHXCPP_X86_64", "-DPLATFORM=android-21"]);
 
 		CPPHelper.rebuild(project, commands);


### PR DESCRIPTION
Latest hashlink requires `uchar.h`, which is only included starting from API level 21.
According to Android Studio, 98% of Android devices run API level 21 or higher.

See also #1517.